### PR TITLE
Bugfix/auto comment

### DIFF
--- a/.github/workflows/auto_comment_template.yaml
+++ b/.github/workflows/auto_comment_template.yaml
@@ -1,11 +1,13 @@
 name: Add PR Review Checklist
 on: [workflow_call]
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
       - uses: wow-actions/auto-comment@v1
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pullRequestOpened: |
             # PR Review Checklist
 


### PR DESCRIPTION
## What is the goal of this PR?

GITHUB_TOKEN added as input secret to allow passing value from calle when calling the auto-comment action, as this is defined as a Required parameter in auto-comment repo.

## What are the changes implemented in this PR?

.github/workflows/auto_comment_template.yaml - change to add GITHUB_TOKEN  to allow passing value from calle