### PR TITLE
GH_TOKEN added as input secret when calling the auto-comment action

### DIFF
--- a/.github/workflows/auto_comment.yaml
+++ b/.github/workflows/auto_comment.yaml
@@ -3,3 +3,5 @@ on: [pull_request]
 jobs:
   add-pr-review-checklist:
     uses: ./.github/workflows/auto_comment_template.yaml
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_comment_template.yaml
+++ b/.github/workflows/auto_comment_template.yaml
@@ -1,5 +1,9 @@
 name: Add PR Review Checklist
-on: [workflow_call]
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
 
 jobs:
   run:
@@ -7,7 +11,7 @@ jobs:
     steps:
       - uses: wow-actions/auto-comment@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           pullRequestOpened: |
             # PR Review Checklist
 


### PR DESCRIPTION
## What is the goal of this PR?

GH_TOKEN added as input secret to allow passing value from calle when calling the auto-comment action, as this is defined as a Required parameter in auto-comment repo.

## What are the changes implemented in this PR?

.github/workflows/auto_comment_template.yaml - change to add GITHUB_TOKEN  to allow passing value from calle