### PR TITLE
add pylint to starter template

### DIFF
--- a/.github/workflows/starter_template.yaml
+++ b/.github/workflows/starter_template.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
 
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 pytest pylint
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Analysing the code with pylint
         run: |


### PR DESCRIPTION
## What is the goal of this PR?

starter template now installs pylint, fixing bug where it would call pylint without having it installed

## What are the changes implemented in this PR?

add pylint to installation during `starter.yaml` github workflow