### PR TITLE
Include CI/CD workflows

### DIFF
--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -1,0 +1,94 @@
+name: Build and deploy SAM template
+
+on:
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: true
+      AWS_DEV_OIDC_ROLE_ARN:
+        required: true
+      AWS_QA_OIDC_ROLE_ARN:
+        required: true
+      AWS_UAT_OIDC_ROLE_ARN:
+        required: true
+    inputs:
+      DEV_TOML_CONFIG:
+        required: false
+        default: dev
+        type: string
+      QA_TOML_CONFIG:
+        required: false
+        default: qa
+        type: string
+      UAT_TOML_CONFIG:
+        required: false
+        default: uat
+        type: string
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+
+jobs:
+  build-sam-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: aws-actions/setup-sam@v2
+      - name: Build SAM
+        run: sam build --use-container -p -c --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: build-sam-template
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: aws-actions/setup-sam@v2
+      - name: Configure AWS credentials for DEV
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
+          role-session-name: samplerolesession
+          aws-region: us-east-2
+      - name: Validate template
+        run: sam validate
+      - name: Deploy SAM template
+        run: sam deploy --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM
+  deploy-qa:
+    runs-on: ubuntu-latest
+    needs: deploy-dev
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: aws-actions/setup-sam@v2
+      - name: Configure AWS credentials for DEV
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_QA_OIDC_ROLE_ARN }}
+          role-session-name: samplerolesession
+          aws-region: us-east-2
+      - name: Validate template
+        run: sam validate
+      - name: Deploy SAM template
+        run: sam deploy --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM
+  deploy-uat:
+    runs-on: ubuntu-latest
+    needs: deploy-qa
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: aws-actions/setup-sam@v2
+      - name: Configure AWS credentials for DEV
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_UAT_OIDC_ROLE_ARN }}
+          role-session-name: samplerolesession
+          aws-region: us-east-2
+      - name: Validate template
+        run: sam validate
+      - name: Deploy SAM template
+        run: sam deploy --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -1,0 +1,48 @@
+name: Build and deploy SAM template
+
+on:
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: true
+      AWS_OIDC_ROLE_ARN:
+        required: true
+    inputs:
+      TOML_CONFIG:
+        required: false
+        default: dev
+        type: string
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+
+jobs:
+  build-sam-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: aws-actions/setup-sam@v2
+      - name: Build SAM
+        run: sam build --use-container -p -c --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+  deploy-sam:
+    runs-on: ubuntu-latest
+    needs: build-sam-template
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: aws-actions/setup-sam@v2
+      - name: Configure AWS credentials for DEV
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-session-name: samplerolesession
+          aws-region: us-east-2
+      - name: Validate template
+        run: sam validate
+      - name: Deploy SAM template
+        run: sam deploy --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM


### PR DESCRIPTION
## What is the goal of this PR?

In this PR we introduce shareable CI/CD workflows for deploying to different environments.

## What are the changes implemented in this PR?

- .github/workflows/build_and_deploy_sam_template.yaml - builds and deploys a SAM template to dev, qa, and UAT. Does not deploy to Prod, because we lack the GitHub edition to have gated deployments.
- .github/workflows/build_and_deploy_sam_template_one_environment.yaml - Build and deploy to a single environment. Should be used in repos to make dev deployment easy, and prod deployments independent of precluded ones (dev, qa, and UAT).