### PR TITLE
Add PAT_GITHUB as a secret for the starter.yaml workflow

### DIFF
--- a/.github/workflows/starter_template.yaml
+++ b/.github/workflows/starter_template.yaml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [workflow_call]
+on:
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}


### PR DESCRIPTION
## What is the goal of this PR?

In this PR we add the PAT_GITHUB secret parameter so that other workflows may call this one when there are private repos in the requirements.txt file.