### PR TITLE
Add optional template name parameter to single env build and deploy

### DIFF
--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --template-file ${{ inputs.TEMPLATE_NAME }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         default: dev
         type: string
+      TEMPLATE_NAME:
+        required: false
+        default: template.yaml
+        type: string
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -36,8 +40,8 @@ jobs:
           role-session-name: samplerolesession
           aws-region: us-east-2
       - name: Build SAM
-        run: sam build --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --template-file ${{ inputs.TEMPLATE_NAME }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset


### PR DESCRIPTION
In this PR we add an optional template name parameter to the CI/CD deploy for a single environment. This allows us to use the script in services that have more than one SAM template.