### PR TITLE
Add workflow for docker+SAM deploys

### DIFF
--- a/.github/workflows/build_and_deploy_docker_to_ecr.yaml
+++ b/.github/workflows/build_and_deploy_docker_to_ecr.yaml
@@ -1,0 +1,47 @@
+name: Build and deploy a docker image to ECR
+
+on: 
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: true
+      AWS_OIDC_ROLE_ARN:
+        required: true
+      AWS_ACCOUNT:
+        required: true
+    inputs:
+      AWS_REGION:
+        required: false
+        default: us-east-2
+        type: string
+      ECR_REPO_NAME:
+        required: true
+        type: string
+
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+
+jobs:
+  login-to-ecr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-session-name: samplerolesession
+          aws-region: us-east-2
+      - name: Login to ECR
+        run: aws ecr get-login-password --region ${{ inputs.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com
+      - name: Build Docker image
+        run: docker build -t ${{ inputs.ECR_REPO_NAME }} . --build-arg GITHUB_TOKEN=$GITHUB_TOKEN
+      - name: Tag Docker image
+        run: docker tag ${{ inputs.ECR_REPO_NAME }}:latest ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_REPO_NAME }}:latest
+      - name: Push Docker image
+        run: docker push ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.ECR_REPO_NAME }}:latest

--- a/.github/workflows/docker_sam_deploy_to_env.yaml
+++ b/.github/workflows/docker_sam_deploy_to_env.yaml
@@ -1,0 +1,49 @@
+name: Docker+SAM deploy for one environment
+
+on: 
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: true
+      AWS_OIDC_ROLE_ARN:
+        required: true
+      AWS_ACCOUNT:
+        required: true
+    inputs:
+      AWS_REGION:
+        required: false
+        default: us-east-2
+        type: string
+      ECR_REPO_NAME:
+        required: true
+        type: string
+      TOML_CONFIG:
+        required: false
+        default: dev
+        type: string
+      TEMPLATE_NAME:
+        required: false
+        default: template.yaml
+        type: string
+
+
+jobs:
+  build-and-deploy-docker-image:
+    uses: Travtus/.github/.github/workflows/build_and_deploy_docker_to_ecr.yaml@main
+    secrets:
+      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+    with:
+      AWS_REGION: ${{ inputs.AWS_REGION }}
+      ECR_REPO_NAME: ${{ inputs.ECR_REPO_NAME }}
+  build-and-deploy-sam-template:
+    needs: build-and-deploy-docker-image
+    uses: Travtus/.github/.github/workflows/build_and_deploy_sam_template_one_environment.yaml@main
+    secrets:
+      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+    with:
+      TOML_CONFIG: ${{ inputs.TOML_CONFIG }}
+      TEMPLATE_NAME: ${{ inputs.TEMPLATE_NAME }}
+  


### PR DESCRIPTION
## What is the goal of this PR?

Add two new workflows.

The build_and_deploy_docker_to_ecr allows for a docker image to be built, tagged with a tag of 'latest' and deployed to the specified AWS account.

The docker_sam_deploy_to_env workflow chains a ECR Docker deploy with a SAM deploy.
