### PR TITLE
PASS samconfig with a different name as input to the templates

### DIFF
--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
   deploy-qa:
     runs-on: ubuntu-latest
     needs: deploy-dev
@@ -77,7 +77,7 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
   deploy-uat:
     runs-on: ubuntu-latest
     needs: deploy-qa

--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -24,7 +24,7 @@ on:
         required: false
         default: uat
         type: string
-      CONFIG_FILE:
+      TOML_CONFIG_FILE:
         required: false
         default: samconfig.toml
         type: string

--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -24,6 +24,10 @@ on:
         required: false
         default: uat
         type: string
+      CONFIG_FILE:
+        required: false
+        default: samconfig.toml
+        type: string
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -52,7 +56,7 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
   deploy-qa:
     runs-on: ubuntu-latest
     needs: deploy-dev
@@ -73,7 +77,7 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
   deploy-uat:
     runs-on: ubuntu-latest
     needs: deploy-qa
@@ -94,4 +98,4 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -98,4 +98,4 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         default: template.yaml
         type: string
+      CONFIG_FILE:
+        required: false
+        default: samconfig.toml
+        type: string
+
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -44,4 +49,4 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -16,7 +16,7 @@ on:
         required: false
         default: template.yaml
         type: string
-      CONFIG_FILE:
+      TOML_CONFIG_FILE:
         required: false
         default: samconfig.toml
         type: string

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -49,4 +49,4 @@ jobs:
       - name: Validate template
         run: sam validate
       - name: Deploy SAM template
-        run: sam deploy --config-file ${{ inputs.CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset
+        run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/docker_sam_deploy_to_env.yaml
+++ b/.github/workflows/docker_sam_deploy_to_env.yaml
@@ -25,6 +25,10 @@ on:
         required: false
         default: template.yaml
         type: string
+      CONFIG_FILE:
+        required: false
+        default: samconfig.toml
+        type: string
 
 
 jobs:
@@ -46,4 +50,4 @@ jobs:
     with:
       TOML_CONFIG: ${{ inputs.TOML_CONFIG }}
       TEMPLATE_NAME: ${{ inputs.TEMPLATE_NAME }}
-  
+      CONFIG_FILE: ${{ inputs.CONFIG_FILE }}

--- a/.github/workflows/docker_sam_deploy_to_env.yaml
+++ b/.github/workflows/docker_sam_deploy_to_env.yaml
@@ -25,7 +25,7 @@ on:
         required: false
         default: template.yaml
         type: string
-      CONFIG_FILE:
+      TOML_CONFIG_FILE:
         required: false
         default: samconfig.toml
         type: string
@@ -50,4 +50,4 @@ jobs:
     with:
       TOML_CONFIG: ${{ inputs.TOML_CONFIG }}
       TEMPLATE_NAME: ${{ inputs.TEMPLATE_NAME }}
-      CONFIG_FILE: ${{ inputs.CONFIG_FILE }}
+      TOML_CONFIG_FILE: ${{ inputs.TOML_CONFIG_FILE }}


### PR DESCRIPTION
## What is the goal of this PR?

Override samconfig.toml with a different name as input to the templates, so that it supports configs stored seperately in the repo as a seperate file with different name.

## What are the changes implemented in this PR?

- .github/workflows/build_and_deploy_sam_template.yaml  - added CONFIG_FILE parameter and referenced it during sam deploy
- .github/workflows/build_and_deploy_sam_template_one_environment.yaml - added CONFIG_FILE parameter and referenced it during sam deploy
- .github/workflows/docker_sam_deploy_to_env.yaml - added CONFIG_FILE parameter and referenced it during sam deploy