### PR TITLE
Use the absolute path for the tag release python script

### DIFF
--- a/.github/workflows/create_main_release.yaml
+++ b/.github/workflows/create_main_release.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           route: GET /repos/Travtus/${{ inputs.REPOSITORY }}/releases/latest
       - id: get_new_tag
-        run: python ./.github/workflows/get_new_tag.py ${{ toJson(steps.get_latest_release_info.outputs.data) }}
+        run: python Travtus/.github/.github/workflows/get_new_tag.py ${{ toJson(steps.get_latest_release_info.outputs.data) }}
   tag-and-release:
     runs-on: ubuntu-latest
     needs: get-new-tag


### PR DESCRIPTION
## What is the goal of this PR?

The workflow for generating a new tag and release referenced a python script for getting the new tag via its relative path. This caused issues when the workflow was used in other repos as the relative path within the importing repo was used instead of the relative path within this repo.

This PR fixes this by using the absolute GitHub path of the python script.