### PR TITLE
Use relative path for the create_main_release workflow script and README updates

### DIFF
--- a/.github/workflows/create_main_release.yaml
+++ b/.github/workflows/create_main_release.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           route: GET /repos/Travtus/${{ inputs.REPOSITORY }}/releases/latest
       - id: get_new_tag
-        run: python Travtus/.github/.github/workflows/get_new_tag.py ${{ toJson(steps.get_latest_release_info.outputs.data) }}
+        run: python ./.github/workflows/get_new_tag.py ${{ toJson(steps.get_latest_release_info.outputs.data) }}
   tag-and-release:
     runs-on: ubuntu-latest
     needs: get-new-tag


### PR DESCRIPTION
## What is the goal of this PR?

Using an absolute path to the script did not fix the issue with using the create_main_release workflow in other repos, so this commit reverts it to the correct relative path.

Updates to the README with instructions for using a workflow from this repo in your own repo and a disclaimer about the create_main_release workflow.