### PR TITLE
Add an action for auto-assigning PRs to the developers group

### DIFF
--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -1,0 +1,14 @@
+name: Auto assigns PR to developers group
+on: [pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/auto-assign@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+          # using the `org/team_slug` or `/team_slug` syntax to add git team as reviewers
+          reviewers: |
+            Travtus/developers
+          addReviewers: true
+          addAssignees: false


### PR DESCRIPTION
We have a developers group that has all of the engineering GH accounts.

We've historically used this in order to make sure that PRs appear in the list of PRs to be reviewed for all developers, however, we've previously had to do this manually and we'd sometimes forget to do this.

This PR adds an action that automatically assigns all PRs to the developers group.