### PR TITLE
No group assignment

### DIFF
--- a/.github/reviewer_config.yml
+++ b/.github/reviewer_config.yml
@@ -24,6 +24,7 @@ files:
     - backend-team
 
 options:
+  enable_group_assignment: false
   ignore_draft: true
   ignored_keywords:
     - DO NOT REVIEW


### PR DESCRIPTION
This pull request includes a small change to the `.github/reviewer_config.yml` file. The change disables group assignment for reviewers. 

* [`.github/reviewer_config.yml`](diffhunk://#diff-adc1e574702e9f44245e6b5736271812386ac0bb3d26fd53a93554584270d874R27): Added `enable_group_assignment: false` to the `options` section.