### PR TITLE
Enable pgvector

### DIFF
--- a/.github/workflows/starter_template.yaml
+++ b/.github/workflows/starter_template.yaml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: ${{ (inputs.ENABLE_POSTGRES_DB) && 'postgres' || '' }}
+        image: ${{ (inputs.ENABLE_POSTGRES_DB) && 'ankane/pgvector' || '' }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/starter_template.yaml` file. The change updates the Docker image used for the PostgreSQL service.

* [`.github/workflows/starter_template.yaml`](diffhunk://#diff-9f60d86049cceb201ab874678fe838199af8f57fcb9728bfee303c2314cf656fL88-R88): Changed the PostgreSQL image from the default `postgres` to `ankane/pgvector` to enable vector support.