### PR TITLE
GitHub token param overrides on build SAM step

### DIFF
--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -70,13 +70,8 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
-      - name: Inject GithubToken into samconfig (if present)
-        run: |
-          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
-            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
-          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN --parameter-overrides GithubToken=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos
   deploy-qa:
@@ -102,13 +97,8 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
-      - name: Inject GithubToken into samconfig (if present)
-        run: |
-          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
-            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
-          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN --parameter-overrides GithubToken=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos
   deploy-uat:
@@ -134,12 +124,7 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
-      - name: Inject GithubToken into samconfig (if present)
-        run: |
-          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
-            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
-          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN --parameter-overrides GithubToken=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos

--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -34,17 +34,16 @@ on:
         type: string
       PYTHON_VERSION:
         type: string
-        default: "3.8"
+        default: '3.8'
         required: false
       ARM_SUPPORT:
         type: boolean
         default: false
         required: false
 
-
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: read # This is required for actions/checkout
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
@@ -71,8 +70,13 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
+      - name: Inject GithubToken into samconfig (if present)
+        run: |
+          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
+            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
+          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos
   deploy-qa:
@@ -98,8 +102,13 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
+      - name: Inject GithubToken into samconfig (if present)
+        run: |
+          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
+            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
+          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos
   deploy-uat:
@@ -125,7 +134,12 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
+      - name: Inject GithubToken into samconfig (if present)
+        run: |
+          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
+            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
+          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.UAT_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -58,12 +58,7 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
-      - name: Inject GithubToken into samconfig (if present)
-        run: |
-          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
-            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
-          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN --parameter-overrides GithubToken=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -22,17 +22,16 @@ on:
         type: string
       PYTHON_VERSION:
         type: string
-        default: "3.8"
+        default: '3.8'
         required: false
       ARM_SUPPORT:
         type: boolean
         default: false
         required: false
 
-
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  contents: read # This is required for actions/checkout
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
@@ -59,7 +58,12 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
+      - name: Inject GithubToken into samconfig (if present)
+        run: |
+          if grep -q 'GithubToken="\$GITHUB_TOKEN"' "${{ inputs.TOML_CONFIG_FILE }}"; then
+            sed -i "s|GithubToken=\"\$GITHUB_TOKEN\"|GithubToken=\"${GITHUB_TOKEN}\"|g" "${{ inputs.TOML_CONFIG_FILE }}"
+          fi
       - name: Build SAM
-        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
+        run: sam build --template-file ${{ inputs.TEMPLATE_NAME }} --use-container -p --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --container-env-var GITHUB_TOKEN=$GITHUB_TOKEN
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos


### PR DESCRIPTION
This pull request updates the build and deployment workflows for AWS SAM templates, primarily to enhance parameter handling during the build process. The main improvements involve passing the `GithubToken` as a parameter override to the SAM build command, ensuring it is available to the template, and minor formatting changes for consistency.

Parameter handling improvements:

* Added `--parameter-overrides GithubToken=$GITHUB_TOKEN` to the `sam build` step in all environments (`dev`, `qa`, `uat`, and single environment) within `.github/workflows/build_and_deploy_sam_template.yaml` and `.github/workflows/build_and_deploy_sam_template_one_environment.yaml`, allowing the template to access the GitHub token as a parameter. [[1]](diffhunk://#diff-670a41d7101fba5a2ecf59e0f61eb54a5dbd8de3b42d2da16a406d7c279fd7c7L75-R74) [[2]](diffhunk://#diff-670a41d7101fba5a2ecf59e0f61eb54a5dbd8de3b42d2da16a406d7c279fd7c7L102-R101) [[3]](diffhunk://#diff-670a41d7101fba5a2ecf59e0f61eb54a5dbd8de3b42d2da16a406d7c279fd7c7L129-R128) [[4]](diffhunk://#diff-86ba2705f941278b3ab85357ed1628281819611a66be6507cd65b0df140128dfL63-R62)

Formatting and consistency:

* Changed the default value for the `PYTHON_VERSION` input from double quotes to single quotes in both workflow files for consistent YAML style. [[1]](diffhunk://#diff-670a41d7101fba5a2ecf59e0f61eb54a5dbd8de3b42d2da16a406d7c279fd7c7L37-L44) [[2]](diffhunk://#diff-86ba2705f941278b3ab85357ed1628281819611a66be6507cd65b0df140128dfL25-L32)