### PR TITLE
Add and update PR size check and rebase verification workflows

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ ready_for_review, opened ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   assign-reviewers:
     uses: Travtus/.github/.github/workflows/auto_assign_template.yml@main

--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
 
-      - name: Calculate changed lines excluding markdown and test folders
+      - name: Calculate changed lines excluding configured non-code paths
         id: diff
         shell: bash
         run: |
@@ -48,7 +48,10 @@ jobs:
               ':(exclude,icase,glob)**/test/**' \
               ':(exclude,icase,glob)**/tests/**' \
               ':(exclude,icase,glob)**/unit_test/**' \
-              ':(exclude,icase,glob)**/unit_tests/**' |
+              ':(exclude,icase,glob)**/unit_tests/**' \
+              ':(exclude,glob)uv.lock' \
+              ':(exclude,glob)pyproject.toml' \
+              ':(exclude,glob).github/workflows/**' |
             awk -F '\t' '
               # FS=\t keeps rename/space paths as NF==3; binaries are "-\t-\t..".
               BEGIN { add = 0; del = 0 }
@@ -61,7 +64,7 @@ jobs:
           )
 
           echo "changed_lines=$CHANGED_LINES" >> "$GITHUB_OUTPUT"
-          echo "Changed lines (excluding docs, test folders, and binary files): $CHANGED_LINES"
+          echo "Changed lines (excluding markdown, test folders, uv.lock, pyproject.toml, .github/workflows, and binary files): $CHANGED_LINES"
 
       - name: Fail if PR exceeds limit
         # Skipped when the 'large-pr-exception' label is present on the PR.
@@ -77,6 +80,6 @@ jobs:
           echo "Actual: $ACTUAL"
 
           if [ "$ACTUAL" -gt "$LIMIT" ]; then
-            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, and binary files). Split this into smaller PRs or add the 'large-pr-exception' label."
+            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, uv.lock, pyproject.toml, .github/workflows, and binary files). Split this into smaller PRs"
             exit 1
           fi

--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -1,0 +1,82 @@
+name: PR Size Check
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-pr-size:
+    name: Enforce PR line limit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v6
+        with:
+          # github.sha is the base tip for pull_request_target, so pin to head.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1 \
+            || git fetch origin "${{ github.base_ref }}"
+
+          if ! git rev-parse --verify "origin/${{ github.base_ref }}" > /dev/null 2>&1; then
+            echo "::error::Could not resolve base branch 'origin/${{ github.base_ref }}'."
+            exit 1
+          fi
+
+      - name: Calculate changed lines excluding markdown and test folders
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE="origin/${{ github.base_ref }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          # (glob) makes ** span zero or more segments (root + nested in one pattern);
+          # (icase) folds .md/.MD and test/Test together.
+          CHANGED_LINES=$(
+            git diff --numstat "$BASE...$HEAD" -- . \
+              ':(exclude,icase,glob)**/*.md' \
+              ':(exclude,icase,glob)**/test/**' \
+              ':(exclude,icase,glob)**/tests/**' \
+              ':(exclude,icase,glob)**/unit_test/**' \
+              ':(exclude,icase,glob)**/unit_tests/**' |
+            awk -F '\t' '
+              # FS=\t keeps rename/space paths as NF==3; binaries are "-\t-\t..".
+              BEGIN { add = 0; del = 0 }
+              /^[0-9]/ && NF == 3 {
+                add += $1
+                del += $2
+              }
+              END { print add + del }
+            '
+          )
+
+          echo "changed_lines=$CHANGED_LINES" >> "$GITHUB_OUTPUT"
+          echo "Changed lines (excluding docs, test folders, and binary files): $CHANGED_LINES"
+
+      - name: Fail if PR exceeds limit
+        # Skipped when the 'large-pr-exception' label is present on the PR.
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'large-pr-exception') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LIMIT=700
+          ACTUAL="${{ steps.diff.outputs.changed_lines }}"
+
+          echo "Limit: $LIMIT"
+          echo "Actual: $ACTUAL"
+
+          if [ "$ACTUAL" -gt "$LIMIT" ]; then
+            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, and binary files). Split this into smaller PRs or add the 'large-pr-exception' label."
+            exit 1
+          fi

--- a/.github/workflows/rebase_checker.yml
+++ b/.github/workflows/rebase_checker.yml
@@ -1,0 +1,50 @@
+name: Rebase Checker
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-up-to-date-with-base:
+    name: Verify the branch contains the latest changes from the PR base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head commit
+        uses: actions/checkout@v6
+        with:
+          # Default merge ref would make the ancestor check trivially pass.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR base branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch origin "${{ github.base_ref }}" --depth=1 \
+            || git fetch origin "${{ github.base_ref }}"
+
+          if ! git rev-parse --verify "origin/${{ github.base_ref }}" > /dev/null 2>&1; then
+            echo "::error::Could not resolve base branch 'origin/${{ github.base_ref }}'."
+            exit 1
+          fi
+
+      - name: Fail if branch is not up to date with the PR base
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE="origin/${{ github.base_ref }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          echo "Checking whether $BASE is an ancestor of $HEAD"
+
+          if git merge-base --is-ancestor "$BASE" "$HEAD"; then
+            echo "Branch includes the latest changes from $BASE"
+          else
+            echo "::error::Deployment blocked. This branch does not include the latest changes from $BASE. Rebase against '${{ github.base_ref }}' before deploying."
+            exit 1
+          fi

--- a/.github/workflows/starter_template.yaml
+++ b/.github/workflows/starter_template.yaml
@@ -89,7 +89,11 @@ env:
   PY_GLOB: "./**/*.py"
 
 jobs:
+  pr-size-check:
+    uses: ./.github/workflows/pr_size_check.yml
+
   build:
+    needs: pr-size-check
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/uv_pull_request_checks.yaml
+++ b/.github/workflows/uv_pull_request_checks.yaml
@@ -57,7 +57,11 @@ env:
   PY_GLOB: "./**/*.py"
 
 jobs:
+  pr-size-check:
+    uses: ./.github/workflows/pr_size_check.yml
+
   build:
+    needs: pr-size-check
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION


## What is the goal of this PR?

This pull request introduces two new reusable GitHub Actions workflows for pull request quality enforcement and integrates them into the project's main CI workflows. The changes aim to ensure PRs are up-to-date with the base branch and do not exceed a configurable size limit, improving code review efficiency and repository health.

**New reusable workflows:**

* **PR Size Check**: Adds `.github/workflows/pr_size_check.yml`, a workflow that calculates the number of changed lines in a PR (excluding documentation, tests, and some config files) and fails if the PR exceeds 700 lines unless a `large-pr-exception` label is present.
* **Rebase Checker**: Adds `.github/workflows/rebase_checker.yml`, a workflow that verifies the PR branch contains the latest changes from the base branch and fails if it is not up to date, prompting the author to rebase.

**Integration into CI workflows:**

* **PR Size Check integration**: Updates `.github/workflows/starter_template.yaml` and `.github/workflows/uv_pull_request_checks.yaml` to invoke the new PR size check workflow before running the main build, blocking further jobs if the check fails. [[1]](diffhunk://#diff-9f60d86049cceb201ab874678fe838199af8f57fcb9728bfee303c2314cf656fR92-R96) [[2]](diffhunk://#diff-253b636c05b2a47afa5aacd74bfe9029307c258474033e3e73a8b04018107519R60-R64)