### PR TITLE
Add pull_request trigger to PR size check workflow

### DIFF
--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -1,6 +1,7 @@
 name: PR Size Check
 
 on:
+  pull_request:
   workflow_call:
 
 permissions:


### PR DESCRIPTION

## What is the goal of this PR?
 
This pull request makes a minor update to the GitHub Actions workflow configuration by specifying that the PR Size Check workflow should also trigger on pull request events.

* Workflow trigger update:
  * [`.github/workflows/pr_size_check.yml`](diffhunk://#diff-eefc00cebeb622c5964e07af08a75362c8ec3bd4cfad9f2bf5832b706412e693R4): Added `pull_request` to the workflow triggers to ensure the PR Size Check runs when a pull request is opened or updated.