### PR TITLE
Fix "no merge base" error in PR size check

### DIFF
--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -24,8 +24,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin "${{ github.base_ref }}" --depth=1 \
-            || git fetch origin "${{ github.base_ref }}"
+          git fetch origin "${{ github.base_ref }}"
 
           if ! git rev-parse --verify "origin/${{ github.base_ref }}" > /dev/null 2>&1; then
             echo "::error::Could not resolve base branch 'origin/${{ github.base_ref }}'."


### PR DESCRIPTION
The "Enforce PR line limit" job fails with `fatal: no merge base` when the PR branch and the base branch (origin/main) do not share a common ancestor in the shallow clone.

This happened because the base branch was fetched with `--depth=1`. If the PR branch diverged from an older commit that is not reachable from the shallow tip of `main`, `git diff BASE...HEAD` fails.

Removing `--depth=1` from the base branch fetch ensures that enough history is available to find the merge base.
