### PR TITLE
docs/feat: sync pr_size_check README and exclude alembic folders

### DIFF
--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -50,6 +50,7 @@ jobs:
               ':(exclude,icase,glob)**/tests/**' \
               ':(exclude,icase,glob)**/unit_test/**' \
               ':(exclude,icase,glob)**/unit_tests/**' \
+              ':(exclude,icase,glob)**/alembic*/**' \
               ':(exclude,glob)**/open_api.yaml' \
               ':(exclude,glob)uv.lock' \
               ':(exclude,glob)pyproject.toml' \
@@ -66,7 +67,7 @@ jobs:
           )
 
           echo "changed_lines=$CHANGED_LINES" >> "$GITHUB_OUTPUT"
-          echo "Changed lines (excluding markdown, test folders, open_api.yaml, uv.lock, pyproject.toml, .github/workflows, and binary files): $CHANGED_LINES"
+          echo "Changed lines (excluding markdown, test folders, alembic folders, open_api.yaml, uv.lock, pyproject.toml, .github/workflows, and binary files): $CHANGED_LINES"
 
       - name: Fail if PR exceeds limit
         # Skipped when the 'large-pr-exception' label is present on the PR.
@@ -82,6 +83,6 @@ jobs:
           echo "Actual: $ACTUAL"
 
           if [ "$ACTUAL" -gt "$LIMIT" ]; then
-            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, open_api.yaml, uv.lock, pyproject.toml, .github/workflows, and binary files). Split this into smaller PRs"
+            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, alembic folders, open_api.yaml, uv.lock, pyproject.toml, .github/workflows, and binary files). Split this into smaller PRs"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Fails a PR when the number of changed lines exceeds **700** (configurable in the
 **Excluded from the line count:**
 - `**/*.md`
 - `**/test/**`, `**/tests/**`, `**/unit_test/**`, `**/unit_tests/**`
+- `**/open_api.yaml`
 - `uv.lock`
 - `pyproject.toml`
 - `.github/workflows/**`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Fails a PR when the number of changed lines exceeds **700** (configurable in the
 **Excluded from the line count:**
 - `**/*.md`
 - `**/test/**`, `**/tests/**`, `**/unit_test/**`, `**/unit_tests/**`
+- `**/alembic*/**`
 - `**/open_api.yaml`
 - `uv.lock`
 - `pyproject.toml`


### PR DESCRIPTION
## What is the goal of this PR?

We updated `pr_size_check.yml` and `README.md` to keep the PR size check accurate and fully documented. Two changes are included:

1. Added `**/alembic*/**` as an excluded path so auto-generated migration files (e.g. `alembic/`, `alembic_migrations/`) do not count toward the 700-line limit.
2. Added `**/open_api.yaml` to the README exclusion list, which was already excluded in the workflow but undocumented.

Both changes ensure contributors have an accurate picture of what counts toward the PR size limit.

## What are the changes implemented in this PR?

- `pr_size_check.yml`: Added `':(exclude,icase,glob)**/alembic*/**'` to the `git diff --numstat` exclusion list. The pattern uses `icase` and `glob` flags to match any folder prefixed with `alembic` at any depth, case-insensitively. The echo and error messages were also updated to mention alembic folders.
- `README.md`: Added `**/alembic*/**` and `**/open_api.yaml` to the documented exclusion list under the `pr_size_check.yml` section, so the docs match the workflow behaviour exactly.