### PR TITLE
feat(pr-size-check): replace PAT with GitHub App token for platform-a…

### DIFF
--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -95,11 +95,20 @@ jobs:
             exit 1
           fi
 
+      - name: Mint Platform Admin review token
+        id: platform-admin-token
+        if: ${{ env.HAS_LARGE_PR_EXCEPTION == 'true' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.PLATFORM_ADMIN_APP_ID }}
+          private-key: ${{ secrets.PLATFORM_ADMIN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Require Platform Admin review for large PR exception
         if: ${{ env.HAS_LARGE_PR_EXCEPTION == 'true' }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PLATFORM_ADMIN_REVIEW_TOKEN || github.token }}
+          github-token: ${{ steps.platform-admin-token.outputs.token }}
           script: |
             const teamSlug = 'platform-admin';
             const { owner, repo } = context.repo;

--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -102,7 +102,8 @@ jobs:
         with:
           app-id: ${{ vars.PLATFORM_ADMIN_APP_ID }}
           private-key: ${{ secrets.PLATFORM_ADMIN_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          # Scope token to the current repo only.
+          repositories: ${{ github.event.repository.name }}
 
       - name: Require Platform Admin review for large PR exception
         if: ${{ env.HAS_LARGE_PR_EXCEPTION == 'true' }}


### PR DESCRIPTION
## What is the goal of this PR?

We removed the user-tied Personal Access Token used by the PR size check's large-PR-exception gate and replaced it with a short-lived GitHub App installation token. Reviewers and contributors continue to see the same gate behaviour (a `large-pr-exception` label requires `@Travtus/platform-admin` approval), but the credential backing it no longer depends on a single user, auto-rotates hourly, and is scoped at runtime to the caller repo. Previously, the workflow read `PLATFORM_ADMIN_REVIEW_TOKEN` (a classic PAT).

  ## What are the changes implemented in this PR?

  - **`.github/workflows/pr_size_check.yml`**: added a `Mint Platform Admin review token` step using `actions/create-github-app-token@v3`. It reads `vars.PLATFORM_ADMIN_APP_ID` and `secrets.PLATFORM_ADMIN_APP_PRIVATE_KEY` (org-level,  scoped to all private repos) and mints an installation token for the caller repo via `owner: ${{github.repository_owner }}`. The downstream `Require Platform Admin review for large PR exception` step now consumes
  - Both steps remain gated by `HAS_LARGE_PR_EXCEPTION == 'true'`, so PRs without the label skip the mint entirely and incur no extra API calls.
 

  ## Notes
  - Pre-provisioned (already in place): GitHub App installation, org variable `PLATFORM_ADMIN_APP_ID`, org secret `PLATFORM_ADMIN_APP_PRIVATE_KEY`, both scoped to all private repos.
  - Public repos in the org are not in scope; if the ruleset is ever extended to a public repo, the mint step will fail because the org secret/var won't be visible there.