### PR TITLE
Update PR size exception handling

### DIFF
--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -60,7 +60,19 @@ jobs:
               ':(exclude,icase,glob)**/alembic*/**' \
               ':(exclude,glob)**/open_api.yaml' \
               ':(exclude,glob)**/requirements*.txt' \
-              ':(exclude,glob)uv.lock' \
+              ':(exclude,glob)**/uv.lock' \
+              ':(exclude,glob)**/poetry.lock' \
+              ':(exclude,glob)**/Pipfile.lock' \
+              ':(exclude,glob)**/package-lock.json' \
+              ':(exclude,glob)**/npm-shrinkwrap.json' \
+              ':(exclude,glob)**/yarn.lock' \
+              ':(exclude,glob)**/pnpm-lock.yaml' \
+              ':(exclude,glob)**/bun.lock' \
+              ':(exclude,glob)**/bun.lockb' \
+              ':(exclude,glob)**/Cargo.lock' \
+              ':(exclude,glob)**/Gemfile.lock' \
+              ':(exclude,glob)**/go.sum' \
+              ':(exclude,glob)**/composer.lock' \
               ':(exclude,glob)pyproject.toml' \
               ':(exclude,glob).github/workflows/**' |
             awk -F '\t' '
@@ -75,7 +87,7 @@ jobs:
           )
 
           echo "changed_lines=$CHANGED_LINES" >> "$GITHUB_OUTPUT"
-          echo "Changed lines (excluding markdown, test folders, alembic folders, open_api.yaml, requirements files, uv.lock, pyproject.toml, .github/workflows, and binary files): $CHANGED_LINES"
+          echo "Changed lines (excluding markdown, test folders, alembic folders, open_api.yaml, requirements files, lockfiles, pyproject.toml, .github/workflows, and binary files): $CHANGED_LINES"
 
       - name: Fail if PR exceeds limit
         # Skipped when the 'large-pr-exception' label is present on the PR.
@@ -91,7 +103,7 @@ jobs:
           echo "Actual: $ACTUAL"
 
           if [ "$ACTUAL" -gt "$LIMIT" ]; then
-            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, alembic folders, open_api.yaml, requirements files, uv.lock, pyproject.toml, .github/workflows, and binary files). Split this into smaller PRs"
+            echo "::error::PR is too large: $ACTUAL changed lines (limit: $LIMIT, excluding markdown, test folders, alembic folders, open_api.yaml, requirements files, lockfiles, pyproject.toml, .github/workflows, and binary files). Split this into smaller PRs"
             exit 1
           fi
 
@@ -114,7 +126,6 @@ jobs:
             const teamSlug = 'platform-admin';
             const { owner, repo } = context.repo;
             const pull_number = process.env.PULL_NUMBER;
-            const headSha = process.env.HEAD_SHA;
 
             let teamMembers;
 
@@ -147,7 +158,6 @@ jobs:
               if (
                 !login ||
                 !platformAdminLogins.has(login) ||
-                review.commit_id !== headSha ||
                 !reviewDecisionStates.has(review.state)
               ) {
                 continue;

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Fails a PR when the number of changed lines exceeds **750** (configurable in the
 
 **Triggers:** `pull_request`, `pull_request_review`
 
-Add the `large-pr-exception` label only when a PR cannot reasonably be split. When the label is present, the size failure is skipped. The workflow requests review from the Platform Admin team and fails until the current PR head has an approval from a member of that team.
+Add the `large-pr-exception` label only when a PR cannot reasonably be split. When the label is present, the size failure is skipped. The workflow requests review from the Platform Admin team and fails until the PR has an approval from a member of that team.
+Platform Admin approval is PR-scoped, not commit-scoped, so a subsequent rebase or synchronize event does not require a fresh approval unless that approval is dismissed or superseded by a later change-requested review from the same admin.
 
 If the Platform Admin team membership is not readable by `GITHUB_TOKEN`, configure `PLATFORM_ADMIN_REVIEW_TOKEN` with access to read org team membership.
 
@@ -33,7 +34,7 @@ If the Platform Admin team membership is not readable by `GITHUB_TOKEN`, configu
 - `**/alembic*/**`
 - `**/open_api.yaml`
 - `**/requirements*.txt`
-- `uv.lock`
+- Lockfiles such as `uv.lock`, `poetry.lock`, `Pipfile.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`, `bun.lockb`, `Cargo.lock`, `Gemfile.lock`, `go.sum`, and `composer.lock`
 - `pyproject.toml`
 - `.github/workflows/**`
 - Binary files (Git reports `-` in numstat)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Fails a PR when the number of changed lines exceeds **750** (configurable in the
 Add the `large-pr-exception` label only when a PR cannot reasonably be split. When the label is present, the size failure is skipped. The workflow requests review from the Platform Admin team and fails until the PR has an approval from a member of that team.
 Platform Admin approval is PR-scoped, not commit-scoped, so a subsequent rebase or synchronize event does not require a fresh approval unless that approval is dismissed or superseded by a later change-requested review from the same admin.
 
-If the Platform Admin team membership is not readable by `GITHUB_TOKEN`, configure `PLATFORM_ADMIN_REVIEW_TOKEN` with access to read org team membership.
+Configure the repository variable `PLATFORM_ADMIN_APP_ID` and secret `PLATFORM_ADMIN_APP_PRIVATE_KEY` for a GitHub App installation that can read org team membership and request PR reviewers.
 
 **Excluded from the line count:**
 - `**/*.md`


### PR DESCRIPTION
## Summary
- exclude common lockfiles from the shared PR size line-count check
- make Platform Admin large-PR approval PR-scoped instead of tied to the current head SHA
- update the README to document both behaviors

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr_size_check.yml"); puts "workflow yaml ok"'`
- simulated the workflow line-count against `Travtus/evaluations-fe#60`; with lockfiles excluded it counts `26` changed lines and only `package.json` remains in numstat

## Notes
`Travtus/evaluations-fe#60` still has a separate CI failure in `npm ci`: the Dependabot PR's `package.json` and `package-lock.json` are out of sync, with missing lockfile entries for `chokidar`, `is-binary-path`, `readdirp`, `binary-extensions`, and `picomatch`.