### PR TITLE
Chore/cdk deploy and bump actions

### DIFF
--- a/.github/workflows/auto_assign_round_robin.yml
+++ b/.github/workflows/auto_assign_round_robin.yml
@@ -27,7 +27,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout central automation
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: Travtus/.github
           ref: ${{ github.workflow_sha }}

--- a/.github/workflows/build_and_deploy_docker_to_ecr.yaml
+++ b/.github/workflows/build_and_deploy_docker_to_ecr.yaml
@@ -35,9 +35,9 @@ jobs:
   login-to-ecr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/build_and_deploy_integration_test_template.yaml
+++ b/.github/workflows/build_and_deploy_integration_test_template.yaml
@@ -65,18 +65,18 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/build_and_deploy_integration_test_template.yaml
+++ b/.github/workflows/build_and_deploy_integration_test_template.yaml
@@ -63,7 +63,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ARM_SUPPORT && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -81,9 +81,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
           aws-region: us-east-2
-      - name: Settings to support ARM Build
-        if: ${{ inputs.ARM_SUPPORT }}
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         if: ${{ inputs.RUN_DEPLOY }}
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}

--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -58,15 +58,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.ENVIRONMENTS == 'dev' || inputs.ENVIRONMENTS == 'all' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - name: Configure AWS credentials for DEV
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
@@ -88,15 +88,15 @@ jobs:
           (inputs.ENVIRONMENTS == 'qa' || inputs.ENVIRONMENTS == 'all') &&
           (needs.deploy-dev.result == 'success' || needs.deploy-dev.result == 'skipped') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - name: Configure AWS credentials for QA
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_QA_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
@@ -118,15 +118,15 @@ jobs:
           (inputs.ENVIRONMENTS == 'uat' || inputs.ENVIRONMENTS == 'all') &&
           (needs.deploy-qa.result == 'success' || needs.deploy-qa.result == 'skipped') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - name: Configure AWS credentials for UAT
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_UAT_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/build_and_deploy_sam_template.yaml
+++ b/.github/workflows/build_and_deploy_sam_template.yaml
@@ -55,7 +55,7 @@ env:
 
 jobs:
   deploy-dev:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ARM_SUPPORT && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     if: ${{ inputs.ENVIRONMENTS == 'dev' || inputs.ENVIRONMENTS == 'all' }}
     steps:
       - uses: actions/checkout@v7
@@ -71,9 +71,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEV_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
           aws-region: us-east-2
-      - name: Settings to support ARM Build
-        if: ${{ inputs.ARM_SUPPORT }}
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
       - name: Build SAM
@@ -81,7 +78,7 @@ jobs:
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.DEV_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos
   deploy-qa:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ARM_SUPPORT && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     needs: [deploy-dev]
     if: >
       ${{ always() &&
@@ -101,9 +98,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_QA_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
           aws-region: us-east-2
-      - name: Settings to support ARM Build
-        if: ${{ inputs.ARM_SUPPORT }}
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
       - name: Build SAM
@@ -111,7 +105,7 @@ jobs:
       - name: Deploy SAM template
         run: sam deploy --config-file ${{ inputs.TOML_CONFIG_FILE }} --config-env ${{ inputs.QA_TOML_CONFIG }} --capabilities CAPABILITY_NAMED_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-image-repos
   deploy-uat:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ARM_SUPPORT && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     needs: [deploy-qa]
     if: >
       ${{ always() &&
@@ -131,9 +125,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_UAT_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
           aws-region: us-east-2
-      - name: Settings to support ARM Build
-        if: ${{ inputs.ARM_SUPPORT }}
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
       - name: Build SAM

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.ARM_SUPPORT && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -53,9 +53,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession
           aws-region: us-east-2
-      - name: Settings to support ARM Build
-        if: ${{ inputs.ARM_SUPPORT }}
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       - name: Validate template
         run: sam validate --template-file ${{ inputs.TEMPLATE_NAME }}
       - name: Build SAM

--- a/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
+++ b/.github/workflows/build_and_deploy_sam_template_one_environment.yaml
@@ -40,15 +40,15 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
         with:
           use-installer: true
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,10 +1,5 @@
 name: Provision infrastructure with CDK
 
-# Universal provisioning step: `cdk deploy` for any repo's infra — RDS, DynamoDB,
-# Lambda (code shipped here), ECR, ECS cluster/service/task-def, S3, etc.
-# cdk synth runs the in-code cdk-nag (AwsSolutions) SOC2 checks and fails on
-# violations before any deploy.
-
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -1,0 +1,79 @@
+name: Provision infrastructure with CDK
+
+# Universal provisioning step: `cdk deploy` for any repo's infra — RDS, DynamoDB,
+# Lambda (code shipped here), ECR, ECS cluster/service/task-def, S3, etc.
+# cdk synth runs the in-code cdk-nag (AwsSolutions) SOC2 checks and fails on
+# violations before any deploy.
+
+on:
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: true
+      AWS_OIDC_ROLE_ARN:
+        required: true
+    inputs:
+      ENV:
+        type: string
+        required: true
+        description: "Environment passed to the CDK app as `-c env=<ENV>` (dev/qa/uat/prod)."
+      CDK_STACKS:
+        type: string
+        required: false
+        default: "--all"
+        description: "Stack selector(s) for cdk deploy. Defaults to all stacks in the app."
+      WORKING_DIRECTORY:
+        type: string
+        required: false
+        default: "."
+        description: "Directory containing cdk.json."
+      PYTHON_VERSION:
+        type: string
+        required: false
+        default: "3.13"
+      NODE_VERSION:
+        type: string
+        required: false
+        default: "20"
+      AWS_REGION:
+        type: string
+        required: false
+        default: "us-east-2"
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-session-name: cdk-deploy
+          aws-region: ${{ inputs.AWS_REGION }}
+      - name: Install dependencies
+        run: uv sync
+      - name: CDK synth (runs cdk-nag SOC2 checks)
+        run: cdk synth -c env=${{ inputs.ENV }}
+      - name: CDK deploy
+        run: cdk deploy ${{ inputs.CDK_STACKS }} -c env=${{ inputs.ENV }} --require-approval never

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: "20"
+      CDK_VERSION:
+        type: string
+        required: false
+        default: "2.1128.0"
+        description: "aws-cdk CLI version. Keep compatible with the app's aws-cdk-lib."
       AWS_REGION:
         type: string
         required: false
@@ -59,7 +64,7 @@ jobs:
         with:
           node-version: ${{ inputs.NODE_VERSION }}
       - name: Install AWS CDK CLI
-        run: npm install -g aws-cdk
+        run: npm install -g aws-cdk@${{ inputs.CDK_VERSION }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -69,6 +74,6 @@ jobs:
       - name: Install dependencies
         run: uv sync
       - name: CDK synth (runs cdk-nag SOC2 checks)
-        run: cdk synth -c env=${{ inputs.ENV }}
+        run: uv run cdk synth -c env=${{ inputs.ENV }}
       - name: CDK deploy
-        run: cdk deploy ${{ inputs.CDK_STACKS }} -c env=${{ inputs.ENV }} --require-approval never
+        run: uv run cdk deploy ${{ inputs.CDK_STACKS }} -c env=${{ inputs.ENV }} --require-approval never

--- a/.github/workflows/checkov_scan.yaml
+++ b/.github/workflows/checkov_scan.yaml
@@ -34,11 +34,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           token: ${{ env.GITHUB_TOKEN }}
       - name: Set up Python ${{ inputs.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
       - name: Run IaC SOC2 scans with checkov

--- a/.github/workflows/create_main_release.yaml
+++ b/.github/workflows/create_main_release.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       new-tag: ${{ steps.get_new_tag.outputs.latest-tag}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: octokit/request-action@v2.x
         id: get_latest_release_info
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,139 @@
+name: Deploy (CDK provision + optional container release)
+
+# Standard deploy entry point for every repo, whatever its shape:
+#   - DynamoDB+Lambda / RDS / serverless  -> DEPLOY_CONTAINER=false (cdk deploy only)
+#   - ECR+ECS, no migrations              -> DEPLOY_CONTAINER=true,  RUN_MIGRATIONS=false
+#   - everything                          -> DEPLOY_CONTAINER=true,  RUN_MIGRATIONS=true
+# CDK provisions all resources (incl. ECR/ECS). The container path then builds
+# the image, pushes to the CDK-provisioned ECR, runs migrations, and rolls ECS.
+
+on:
+  workflow_call:
+    secrets:
+      PAT_GITHUB:
+        required: true
+      AWS_OIDC_ROLE_ARN:
+        required: true
+      AWS_ACCOUNT:
+        required: false
+        description: "Required only when DEPLOY_CONTAINER is true (ECR login/push)."
+    inputs:
+      ENV:
+        type: string
+        required: true
+      CDK_STACKS:
+        type: string
+        required: false
+        default: "--all"
+      WORKING_DIRECTORY:
+        type: string
+        required: false
+        default: "."
+      PYTHON_VERSION:
+        type: string
+        required: false
+        default: "3.13"
+      NODE_VERSION:
+        type: string
+        required: false
+        default: "20"
+      AWS_REGION:
+        type: string
+        required: false
+        default: "us-east-2"
+      DEPLOY_CONTAINER:
+        type: boolean
+        required: false
+        default: false
+        description: "Build+push image and roll the ECS service after provisioning."
+      RUN_MIGRATIONS:
+        type: boolean
+        required: false
+        default: false
+        description: "Run Alembic migrations (with the new image) before the ECS rollout."
+      # --- container release passthrough (only used when DEPLOY_CONTAINER) ---
+      ECR_REPO_NAME:
+        type: string
+        required: false
+        default: ""
+      DOCKER_CONTEXT:
+        type: string
+        required: false
+        default: "."
+      ECS_CLUSTER_NAME:
+        type: string
+        required: false
+        default: ""
+      TASK_DEF:
+        type: string
+        required: false
+        default: ""
+      CONTAINER_NAME:
+        type: string
+        required: false
+        default: ""
+      SUBNET_IDS:
+        type: string
+        required: false
+        default: ""
+      SECURITY_GROUP_ID:
+        type: string
+        required: false
+        default: ""
+      MIGRATION_COMMAND:
+        type: string
+        required: false
+        default: "upgrade head"
+
+jobs:
+  provision:
+    uses: ./.github/workflows/cdk-deploy.yml
+    secrets:
+      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+    with:
+      ENV: ${{ inputs.ENV }}
+      CDK_STACKS: ${{ inputs.CDK_STACKS }}
+      WORKING_DIRECTORY: ${{ inputs.WORKING_DIRECTORY }}
+      PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
+      NODE_VERSION: ${{ inputs.NODE_VERSION }}
+      AWS_REGION: ${{ inputs.AWS_REGION }}
+
+  build:
+    needs: provision
+    if: ${{ inputs.DEPLOY_CONTAINER }}
+    uses: ./.github/workflows/build_and_deploy_docker_to_ecr.yaml
+    secrets:
+      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
+    with:
+      AWS_REGION: ${{ inputs.AWS_REGION }}
+      ECR_REPO_NAME: ${{ inputs.ECR_REPO_NAME }}
+      DOCKER_CONTEXT: ${{ inputs.DOCKER_CONTEXT }}
+
+  migrate:
+    needs: build
+    if: ${{ inputs.DEPLOY_CONTAINER && inputs.RUN_MIGRATIONS }}
+    uses: ./.github/workflows/run-alembic-migrations.yml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+    with:
+      ECS_CLUSTER_NAME: ${{ inputs.ECS_CLUSTER_NAME }}
+      TASK_DEF: ${{ inputs.TASK_DEF }}
+      CONTAINER_NAME: ${{ inputs.CONTAINER_NAME }}
+      SUBNET_IDS: ${{ inputs.SUBNET_IDS }}
+      SECURITY_GROUP_ID: ${{ inputs.SECURITY_GROUP_ID }}
+      MIGRATION_COMMAND: ${{ inputs.MIGRATION_COMMAND }}
+      AWS_REGION: ${{ inputs.AWS_REGION }}
+      ECR_REPO_NAME: ${{ inputs.ECR_REPO_NAME }}
+
+  restart:
+    needs: [build, migrate]
+    if: ${{ always() && inputs.DEPLOY_CONTAINER && needs.build.result == 'success' && (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') }}
+    uses: ./.github/workflows/restart-ecs-services-template.yaml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+    with:
+      ECS_CLUSTER_NAME: ${{ inputs.ECS_CLUSTER_NAME }}
+      AWS_REGION: ${{ inputs.AWS_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,5 @@
 name: Deploy (CDK provision + optional container release)
 
-# Standard deploy entry point for every repo, whatever its shape:
-#   - DynamoDB+Lambda / RDS / serverless  -> DEPLOY_CONTAINER=false (cdk deploy only)
-#   - ECR+ECS, no migrations              -> DEPLOY_CONTAINER=true,  RUN_MIGRATIONS=false
-#   - everything                          -> DEPLOY_CONTAINER=true,  RUN_MIGRATIONS=true
-# CDK provisions all resources (incl. ECR/ECS). The container path then builds
-# the image, pushes to the CDK-provisioned ECR, runs migrations, and rolls ECS.
-
 on:
   workflow_call:
     secrets:
@@ -51,7 +44,6 @@ on:
         required: false
         default: false
         description: "Run Alembic migrations (with the new image) before the ECS rollout."
-      # --- container release passthrough (only used when DEPLOY_CONTAINER) ---
       ECR_REPO_NAME:
         type: string
         required: false

--- a/.github/workflows/install_and_zip_and_upload_to_s3.yaml
+++ b/.github/workflows/install_and_zip_and_upload_to_s3.yaml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.8'
       - run: |
@@ -45,7 +45,7 @@ jobs:
           cd ./venv/lib/python3.8/site-packages
           zip -r -q ${{ inputs.PACKAGE_NAME }}.zip ${{ inputs.PACKAGE_NAME }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout PR HEAD
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Pin to the PR head so review events diff the same commit under review.
           ref: ${{ env.HEAD_SHA }}

--- a/.github/workflows/rebase_checker.yml
+++ b/.github/workflows/rebase_checker.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout PR head commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Default merge ref would make the ancestor check trivially pass.
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/restart-ecs-services-template.yaml
+++ b/.github/workflows/restart-ecs-services-template.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: inputs.ECS_CLUSTER_NAME != ''
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/run_behave_tests.yaml
+++ b/.github/workflows/run_behave_tests.yaml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/starter_template.yaml
+++ b/.github/workflows/starter_template.yaml
@@ -117,11 +117,11 @@ jobs:
           CLICKHOUSE_USER: default
           CLICKHOUSE_PASSWORD: mypassword
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ env.GITHUB_TOKEN }}
       - name: Set up Python ${{ inputs.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
       - name: Install clickhouse-client
@@ -130,7 +130,7 @@ jobs:
           sudo apt update
           sudo apt install -y clickhouse-client
       - name: Get file changes
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           list-files: shell

--- a/.github/workflows/upload_to_s3.yaml
+++ b/.github/workflows/upload_to_s3.yaml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
           role-session-name: samplerolesession

--- a/.github/workflows/uv_pull_request_checks.yaml
+++ b/.github/workflows/uv_pull_request_checks.yaml
@@ -85,11 +85,11 @@ jobs:
           CLICKHOUSE_USER: default
           CLICKHOUSE_PASSWORD: mypassword
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ env.GITHUB_TOKEN }}
       - name: Set up Python ${{ inputs.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
       - name: Install clickhouse-client
@@ -98,7 +98,7 @@ jobs:
           sudo apt update
           sudo apt install -y clickhouse-client
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Install deps via UV
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}

--- a/.github/workflows/zip_and_upload_to_s3.yaml
+++ b/.github/workflows/zip_and_upload_to_s3.yaml
@@ -30,13 +30,13 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Zip file
         run: |
           cd ${{ inputs.DIRECTORY_LOCATION }}/..
           zip -r -q ${{ inputs.PACKAGE_NAME }}.zip ${{ inputs.PACKAGE_NAME }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
           role-session-name: samplerolesession


### PR DESCRIPTION
## What is the goal of this PR?

### New reusable workflows
  - **`cdk-deploy.yml`** — universal CDK provisioning step for any repository's infrastructure (RDS, DynamoDB, Lambda, ECR, ECS, S3, …). Runs `cdk synth` (executing the in-code `cdk-nag` AwsSolutions checks and failing on violations) before `cdk deploy`. Uses OIDC role assumption, `uv`, and the CDK CLI.
  - **`deploy.yml`** — single deployment entry point for every repository shape, driven by capability toggles:

    | Repository type | `DEPLOY_CONTAINER` | `RUN_MIGRATIONS` |
    | --- | --- | --- |
    | DynamoDB + Lambda / RDS / serverless | `false` | `false` |
    | ECR + ECS, no migrations | `true` | `false` |
    | Full stack | `true` | `true` |

    CDK provisions all resources (including ECR/ECS). When `DEPLOY_CONTAINER` is enabled, the image is built, pushed to the CDK-provisioned ECR, migrated (Alembic), and rolled out to ECS — reusing the existing `build_and_deploy_docker_to_ecr`, `run-alembic-migrations`, and `restart-ecs-services-template` workflows.
  
  ### GitHub Actions upgraded (16 workflows)

  | Action | Before | After |
  | --- | --- | --- |
  | `actions/checkout` | v3 / v4 | **v7** |
  | `actions/setup-python` | v4 / v5 | **v6** |
  | `aws-actions/configure-aws-credentials` | v1 / v4 | **v6** |
  | `aws-actions/setup-sam` | v2 | **v3** |
  | `astral-sh/setup-uv` | v5 | **v8.2.0** (pinned — floating major tag removed upstream) |
  | `actions/setup-node` | v4 | **v6** |
  | `dorny/paths-filter` | v2 | **v4** |
  
  Already current and left unchanged: `create-github-app-token@v3`, `github-script@v8`, `upload-artifact@v4`.

  ### Native ARM builds
  SAM jobs with `ARM_SUPPORT: true` now run on **`ubuntu-24.04-arm`** instead of emulating arm64 via QEMU (`multiarch/qemu-user-static`) on x86. The QEMU setup step has been removed from all 5 build/deploy jobs, significantly speeding up arm64 builds. Callers continue to pass `ARM_SUPPORT` unchanged; x86 jobs remain on `ubuntu-latest`.
