### PR TITLE
fix(auto-reviewer): exclude PR author's own reviews from existing-reviewer check

### DIFF
--- a/.github/scripts/auto_reviewer.py
+++ b/.github/scripts/auto_reviewer.py
@@ -305,7 +305,14 @@ class ReviewerAutomation:
             print(f"No reviewer team matched changed files; defaulting to {default_team}.")
             matched_teams = [default_team]
 
-        existing_reviewers = self.github.list_existing_reviewers(owner, repo, pull_number)
+        # A PR author who comments on their own PR (e.g. replying to automated review
+        # feedback) shows up in the reviews list but never satisfies a team's review
+        # requirement, so they must not count toward "this team already has a reviewer".
+        existing_reviewers = [
+            reviewer
+            for reviewer in self.github.list_existing_reviewers(owner, repo, pull_number)
+            if reviewer.lower() != pr_author.lower()
+        ]
         state, comment_id, previous_body = self.github.get_state_comment(
             self.state_owner,
             self.state_repo,

--- a/.github/scripts/test_auto_reviewer.py
+++ b/.github/scripts/test_auto_reviewer.py
@@ -1,0 +1,131 @@
+# Standard library
+from __future__ import annotations
+
+from typing import Any
+
+# First-party
+from auto_reviewer import ReviewerAutomation
+
+JsonDict = dict[str, Any]
+
+CONFIG: JsonDict = {
+    "teams": {
+        "Platform": {
+            "github_team": "Platform",
+            "slack_channel": "C0A035FRREE",
+            "extensions": [".py"],
+        },
+    },
+}
+
+
+class FakeGithub:
+    def __init__(
+        self,
+        team_members: list[str],
+        existing_reviewers: list[str],
+        changed_files: list[str] | None = None,
+        state: JsonDict | None = None,
+    ) -> None:
+        self.team_members = team_members
+        self.existing_reviewers = existing_reviewers
+        self.changed_files = changed_files or ["src/app.py"]
+        self.state = state or {}
+        self.requested_reviewers: list[str] = []
+        self.updated_state: JsonDict | None = None
+
+    def list_pull_request_files(self, owner: str, repo: str, pull_number: int) -> list[str]:
+        return self.changed_files
+
+    def list_team_members(self, org: str, team_slug: str) -> list[str]:
+        return self.team_members
+
+    def get_state_comment(
+        self, owner: str, repo: str, issue_number: int, marker: str
+    ) -> tuple[JsonDict, int, str]:
+        return dict(self.state), 1, ""
+
+    def update_state_comment(
+        self,
+        owner: str,
+        repo: str,
+        comment_id: int,
+        state: JsonDict,
+        previous_body: str,
+        marker: str,
+    ) -> None:
+        self.updated_state = state
+
+    def request_reviewer(self, owner: str, repo: str, pull_number: int, reviewer: str) -> bool:
+        self.requested_reviewers.append(reviewer)
+        return True
+
+    def list_existing_reviewers(self, owner: str, repo: str, pull_number: int) -> list[str]:
+        return self.existing_reviewers
+
+
+class FakeSlack:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def post_message(self, channel: str, text: str) -> None:
+        self.messages.append((channel, text))
+
+
+def _make_automation(github: FakeGithub, slack: FakeSlack) -> ReviewerAutomation:
+    return ReviewerAutomation(
+        github=github,
+        slack=slack,
+        config=CONFIG,
+        state_owner="Travtus",
+        state_repo=".github",
+        state_issue_number=70,
+    )
+
+
+def test_author_self_review_does_not_block_round_robin() -> None:
+    """A PR author who replies to their own PR still gets a teammate assigned.
+
+    Regression test: list_existing_reviewers previously included the PR author's own
+    review activity (e.g. replying to automated feedback), which made the script think
+    the author's team already had a reviewer and skipped assignment entirely.
+    """
+    github = FakeGithub(
+        team_members=["Jamkasz", "rangan-anand", "nikkogg", "muhammad-tkhan"],
+        existing_reviewers=["Jamkasz", "copilot-pull-request-reviewer"],
+    )
+    slack = FakeSlack()
+    automation = _make_automation(github, slack)
+
+    result = automation.run(
+        owner="Travtus",
+        repo="platform-config-service",
+        pull_number=19,
+        pr_author="Jamkasz",
+        pr_url="https://github.com/Travtus/platform-config-service/pull/19",
+    )
+
+    # Tie-break among eligible teammates (all with 0 prior assignments) is alphabetical.
+    assert result.assigned_reviewers == {"Platform": "muhammad-tkhan"}
+    assert github.requested_reviewers == ["muhammad-tkhan"]
+
+
+def test_real_teammate_review_still_blocks_reassignment() -> None:
+    """A genuine teammate review still counts and prevents a duplicate assignment."""
+    github = FakeGithub(
+        team_members=["Jamkasz", "rangan-anand", "nikkogg", "muhammad-tkhan"],
+        existing_reviewers=["Jamkasz", "rangan-anand"],
+    )
+    slack = FakeSlack()
+    automation = _make_automation(github, slack)
+
+    result = automation.run(
+        owner="Travtus",
+        repo="platform-config-service",
+        pull_number=19,
+        pr_author="Jamkasz",
+        pr_url="https://github.com/Travtus/platform-config-service/pull/19",
+    )
+
+    assert result.assigned_reviewers == {}
+    assert github.requested_reviewers == []


### PR DESCRIPTION
## Summary
Fixes a bug in `auto_reviewer.py` where a PR author's own review activity (e.g. replying to automated review-bot feedback) could be mistaken for a completed team review, silently skipping round-robin reviewer assignment.

## Why
Discovered on `Travtus/platform-config-service#19`: the round-robin workflow ran successfully but assigned no one, logging `Every matched team already has a reviewer.` The PR author is a member of the matched `Platform` team, and had posted several reply-comments addressing Copilot's automated review feedback. Each reply is recorded by GitHub as a "review" from that user. `list_existing_reviewers()` folds pending review requests together with everyone who has submitted a review, but never excludes the PR author — so the author's own reply-comments made `_select_reviewers` think a Platform teammate had already reviewed, and it skipped the team entirely instead of picking a real reviewer via round robin.

## Changes Made
- Filter the PR author out of `existing_reviewers` at the call site in `ReviewerAutomation.run()`, before the existing-reviewer gate in `_select_reviewers` runs. `pick_round_robin_reviewer` already excluded the author from *eligible* candidates — this closes the earlier gate that was short-circuiting before that logic ever ran.
- Added `.github/scripts/test_auto_reviewer.py` with fake `GithubApi`/`SlackApi` implementations (the code was already structured with `Protocol` interfaces for this), covering:
  - The regression scenario: author is a team member and has "reviewed" via a self-reply — a real teammate still gets assigned.
  - The non-regression case: a genuine teammate review still correctly blocks reassignment.

## Test Plan
- `python3 -m pytest .github/scripts/test_auto_reviewer.py -v` — 2/2 pass
- Verified the new regression test fails without the fix (reproduces the exact `Every matched team already has a reviewer.` log line seen in production) and passes with it
- `ruff check` and `mypy` both clean on the changed file