### PR TITLE
fix(pr-size): resolve "no merge base" in changed-lines check

### DIFF
--- a/.github/workflows/pr_size_check.yml
+++ b/.github/workflows/pr_size_check.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin "$BASE_REF" --depth=1 || git fetch origin "$BASE_REF"
+          git fetch --no-tags origin "$BASE_REF" --unshallow 2>/dev/null || git fetch --no-tags origin "$BASE_REF"
 
           if ! git rev-parse --verify "origin/$BASE_REF" > /dev/null 2>&1; then
             echo "::error::Could not resolve base branch 'origin/$BASE_REF'."


### PR DESCRIPTION
The PR-size check fetched the base branch with `--depth=1` (and the `|| full fetch` fallback never fired since depth-1 succeeds), leaving `origin/$BASE_REF` shallow with no ancestors. The triple-dot `git diff origin/$BASE_REF...$HEAD` then aborted with `fatal: ... no merge base`. Now fetches the base's full history so the merge-base with HEAD (already deep via `fetch-depth: 0`) resolves. Fixes the check across all repos.