### PR TITLE
Add image tag support to CDK deploy workflow

### DIFF
--- a/.github/scripts/test_cdk_deploy_workflow.py
+++ b/.github/scripts/test_cdk_deploy_workflow.py
@@ -28,8 +28,20 @@ def test_private_dependency_credentials_are_ephemeral_and_verified() -> None:
 def test_image_tag_is_validated_and_passed_to_synth_and_deploy() -> None:
     assert "if: ${{ inputs.IMAGE_TAG != '' }}" in WORKFLOW
     assert '[[ ! "$IMAGE_TAG" =~ ^[0-9a-f]{40}$ ]]' in WORKFLOW
-    assert WORKFLOW.count('args+=(-c "imageTag=$IMAGE_TAG")') == 2
+    assert WORKFLOW.count('args+=(-c "imageTag=$IMAGE_TAG")') == 1
     assert "IMAGE_TAG: ${{ github.sha }}" in CDK_README
+
+
+def test_deploy_uses_reviewed_cloud_assembly_after_environment_approval() -> None:
+    assert "  preview:" in WORKFLOW
+    assert "  provision:" in WORKFLOW
+    assert "needs: preview" in WORKFLOW
+    assert "cdk diff" in WORKFLOW
+    assert "actions/upload-artifact@v6" in WORKFLOW
+    assert "actions/download-artifact@v7" in WORKFLOW
+    assert "environment: ${{ inputs.ENV }}" in WORKFLOW
+    assert "--app cdk.out" in WORKFLOW
+    assert WORKFLOW.index("uv run cdk diff") < WORKFLOW.index("- name: CDK deploy")
 
 
 def test_readme_documents_the_caller_contract() -> None:
@@ -43,4 +55,5 @@ if __name__ == "__main__":
     test_private_dependencies_use_scoped_github_app_auth()
     test_private_dependency_credentials_are_ephemeral_and_verified()
     test_image_tag_is_validated_and_passed_to_synth_and_deploy()
+    test_deploy_uses_reviewed_cloud_assembly_after_environment_approval()
     test_readme_documents_the_caller_contract()

--- a/.github/scripts/test_cdk_deploy_workflow.py
+++ b/.github/scripts/test_cdk_deploy_workflow.py
@@ -44,6 +44,14 @@ def test_deploy_uses_reviewed_cloud_assembly_after_environment_approval() -> Non
     assert WORKFLOW.index("uv run cdk diff") < WORKFLOW.index("- name: CDK deploy")
 
 
+def test_plan_only_publishes_diff_without_provisioning() -> None:
+    assert "PLAN_ONLY:" in WORKFLOW
+    assert "if: ${{ !inputs.PLAN_ONLY }}" in WORKFLOW
+    assert "--no-change-set" in WORKFLOW
+    assert "GITHUB_STEP_SUMMARY" in WORKFLOW
+    assert "`PLAN_ONLY`" in CDK_README
+
+
 def test_readme_documents_the_caller_contract() -> None:
     assert "`PAT_GITHUB`" not in CDK_README
     assert "`PLATFORM_ADMIN_APP_ID`" in CDK_README
@@ -56,4 +64,5 @@ if __name__ == "__main__":
     test_private_dependency_credentials_are_ephemeral_and_verified()
     test_image_tag_is_validated_and_passed_to_synth_and_deploy()
     test_deploy_uses_reviewed_cloud_assembly_after_environment_approval()
+    test_plan_only_publishes_diff_without_provisioning()
     test_readme_documents_the_caller_contract()

--- a/.github/scripts/test_cdk_deploy_workflow.py
+++ b/.github/scripts/test_cdk_deploy_workflow.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = (REPO_ROOT / ".github/workflows/cdk-deploy.yml").read_text()
+README = (REPO_ROOT / "README.md").read_text()
+CDK_README = README.split("### `cdk-deploy.yml`", maxsplit=1)[1].split("\n### ", maxsplit=1)[0]
+
+
+def test_private_dependencies_use_scoped_github_app_auth() -> None:
+    assert "PAT_GITHUB" not in WORKFLOW
+    assert "PLATFORM_ADMIN_APP_PRIVATE_KEY" in WORKFLOW
+    assert "PRIVATE_DEPENDENCY_REPOSITORIES" in WORKFLOW
+    assert "actions/create-github-app-token@v3" in WORKFLOW
+    assert "client-id: ${{ vars.PLATFORM_ADMIN_APP_ID }}" in WORKFLOW
+    assert "permission-contents: read" in WORKFLOW
+
+
+def test_private_dependency_credentials_are_ephemeral_and_verified() -> None:
+    assert "persist-credentials: false" in WORKFLOW
+    assert "trap cleanup_git_auth EXIT" in WORKFLOW
+    assert "git ls-remote --exit-code" in WORKFLOW
+    assert "uv sync --all-groups --frozen" in WORKFLOW
+
+
+def test_readme_documents_the_caller_contract() -> None:
+    assert "`PAT_GITHUB`" not in CDK_README
+    assert "`PLATFORM_ADMIN_APP_ID`" in CDK_README
+    assert "`PLATFORM_ADMIN_APP_PRIVATE_KEY`" in CDK_README
+    assert "`PRIVATE_DEPENDENCY_REPOSITORIES`" in CDK_README
+
+
+if __name__ == "__main__":
+    test_private_dependencies_use_scoped_github_app_auth()
+    test_private_dependency_credentials_are_ephemeral_and_verified()
+    test_readme_documents_the_caller_contract()

--- a/.github/scripts/test_cdk_deploy_workflow.py
+++ b/.github/scripts/test_cdk_deploy_workflow.py
@@ -25,6 +25,13 @@ def test_private_dependency_credentials_are_ephemeral_and_verified() -> None:
     assert "uv sync --all-groups --frozen" in WORKFLOW
 
 
+def test_image_tag_is_validated_and_passed_to_synth_and_deploy() -> None:
+    assert "if: ${{ inputs.IMAGE_TAG != '' }}" in WORKFLOW
+    assert '[[ ! "$IMAGE_TAG" =~ ^[0-9a-f]{40}$ ]]' in WORKFLOW
+    assert WORKFLOW.count('args+=(-c "imageTag=$IMAGE_TAG")') == 2
+    assert "IMAGE_TAG: ${{ github.sha }}" in CDK_README
+
+
 def test_readme_documents_the_caller_contract() -> None:
     assert "`PAT_GITHUB`" not in CDK_README
     assert "`PLATFORM_ADMIN_APP_ID`" in CDK_README
@@ -35,4 +42,5 @@ def test_readme_documents_the_caller_contract() -> None:
 if __name__ == "__main__":
     test_private_dependencies_use_scoped_github_app_auth()
     test_private_dependency_credentials_are_ephemeral_and_verified()
+    test_image_tag_is_validated_and_passed_to_synth_and_deploy()
     test_readme_documents_the_caller_contract()

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -54,6 +54,11 @@ on:
         required: false
         default: "cdk"
         description: "Stable letters/digits/dot/dash/underscore id used for the reviewed cloud-assembly artifact."
+      PLAN_ONLY:
+        type: boolean
+        required: false
+        default: false
+        description: "Run synth and diff without provisioning. Intended for pull-request plans."
 
 permissions:
   contents: read
@@ -165,10 +170,28 @@ jobs:
       - name: Preview CDK changes
         env:
           CDK_STACKS: ${{ inputs.CDK_STACKS }}
+          DEPLOY_ENV: ${{ inputs.ENV }}
           NO_COLOR: "1"
+          PLAN_ONLY: ${{ inputs.PLAN_ONLY }}
         run: |
           read -r -a stacks <<< "$CDK_STACKS"
-          uv run cdk diff "${stacks[@]}" --app cdk.out
+          diff_args=("${stacks[@]}" --app cdk.out)
+          if [ "$PLAN_ONLY" = "true" ]; then
+            diff_args+=(--no-change-set)
+          fi
+
+          set +e
+          uv run cdk diff "${diff_args[@]}" 2>&1 | tee "$RUNNER_TEMP/cdk-diff.txt"
+          diff_status=${PIPESTATUS[0]}
+          set -e
+
+          {
+            printf '### CDK diff: `%s`\n\n' "$DEPLOY_ENV"
+            echo '```text'
+            cat "$RUNNER_TEMP/cdk-diff.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$diff_status"
       - name: Upload reviewed cloud assembly
         uses: actions/upload-artifact@v6
         with:
@@ -179,6 +202,7 @@ jobs:
 
   provision:
     needs: preview
+    if: ${{ !inputs.PLAN_ONLY }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.ENV }}
     permissions:

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -49,14 +49,21 @@ on:
         required: false
         default: "platform-infra-toolkit"
         description: "Newline-separated Travtus repositories readable by the dependency GitHub App token."
+      DEPLOYMENT_ID:
+        type: string
+        required: false
+        default: "cdk"
+        description: "Stable letters/digits/dot/dash/underscore id used for the reviewed cloud-assembly artifact."
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
-  provision:
+  preview:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
@@ -126,6 +133,7 @@ jobs:
           fi
       - name: Validate deploy inputs
         env:
+          DEPLOYMENT_ID: ${{ inputs.DEPLOYMENT_ID }}
           DEPLOY_ENV: ${{ inputs.ENV }}
           CDK_STACKS: ${{ inputs.CDK_STACKS }}
         run: |
@@ -140,6 +148,10 @@ jobs:
             echo "CDK_STACKS must be --all or space-separated CDK stack names."
             exit 1
           fi
+          if [[ ! "$DEPLOYMENT_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "DEPLOYMENT_ID must use only letters, digits, dot, dash, and underscore."
+            exit 1
+          fi
       - name: CDK synth (runs cdk-nag SOC2 checks)
         env:
           DEPLOY_ENV: ${{ inputs.ENV }}
@@ -150,15 +162,50 @@ jobs:
             args+=(-c "imageTag=$IMAGE_TAG")
           fi
           uv run cdk synth "${args[@]}"
-      - name: CDK deploy
+      - name: Preview CDK changes
         env:
-          DEPLOY_ENV: ${{ inputs.ENV }}
           CDK_STACKS: ${{ inputs.CDK_STACKS }}
-          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+          NO_COLOR: "1"
         run: |
           read -r -a stacks <<< "$CDK_STACKS"
-          args=("${stacks[@]}" -c "env=$DEPLOY_ENV")
-          if [ -n "$IMAGE_TAG" ]; then
-            args+=(-c "imageTag=$IMAGE_TAG")
-          fi
-          uv run cdk deploy "${args[@]}" --require-approval never
+          uv run cdk diff "${stacks[@]}" --app cdk.out
+      - name: Upload reviewed cloud assembly
+        uses: actions/upload-artifact@v6
+        with:
+          name: cdk-assembly-${{ inputs.DEPLOYMENT_ID }}
+          path: ${{ inputs.WORKING_DIRECTORY }}/cdk.out
+          if-no-files-found: error
+          retention-days: 1
+
+  provision:
+    needs: preview
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.ENV }}
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: ${{ inputs.WORKING_DIRECTORY }}
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: cdk-assembly-${{ inputs.DEPLOYMENT_ID }}
+          path: ${{ inputs.WORKING_DIRECTORY }}/cdk.out
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk@${{ inputs.CDK_VERSION }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-session-name: cdk-deploy
+          aws-region: ${{ inputs.AWS_REGION }}
+      - name: CDK deploy
+        env:
+          CDK_STACKS: ${{ inputs.CDK_STACKS }}
+        run: |
+          read -r -a stacks <<< "$CDK_STACKS"
+          cdk deploy "${stacks[@]}" --app cdk.out --require-approval never

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -3,7 +3,7 @@ name: Provision infrastructure with CDK
 on:
   workflow_call:
     secrets:
-      PAT_GITHUB:
+      PLATFORM_ADMIN_APP_PRIVATE_KEY:
         required: true
       AWS_OIDC_ROLE_ARN:
         required: true
@@ -44,6 +44,11 @@ on:
         required: false
         default: ""
         description: "Optional full 40-character lowercase hex commit SHA passed to CDK as `-c imageTag=<IMAGE_TAG>`."
+      PRIVATE_DEPENDENCY_REPOSITORIES:
+        type: string
+        required: false
+        default: "platform-infra-toolkit"
+        description: "Newline-separated Travtus repositories readable by the dependency GitHub App token."
 
 permissions:
   id-token: write
@@ -73,18 +78,43 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: cdk-deploy
           aws-region: ${{ inputs.AWS_REGION }}
+      - name: Create GitHub App token for private dependencies
+        id: private-dependency-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PLATFORM_ADMIN_APP_ID }}
+          private-key: ${{ secrets.PLATFORM_ADMIN_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ inputs.PRIVATE_DEPENDENCY_REPOSITORIES }}
+          permission-contents: read
       - name: Install dependencies
         env:
-          PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+          PRIVATE_DEPENDENCY_REPOSITORIES: ${{ inputs.PRIVATE_DEPENDENCY_REPOSITORIES }}
+          PRIVATE_DEPENDENCY_TOKEN: ${{ steps.private-dependency-token.outputs.token }}
         run: |
-          if [ -z "$PAT_GITHUB" ]; then
-            echo "PAT_GITHUB is required for private Python dependencies."
+          cleanup_git_auth() {
+            git config --global --unset-all url."https://x-access-token:${PRIVATE_DEPENDENCY_TOKEN}@github.com/".insteadOf || true
+          }
+          trap cleanup_git_auth EXIT
+          git config --global url."https://x-access-token:${PRIVATE_DEPENDENCY_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+          repository_count=0
+          while IFS= read -r repository; do
+            repository="${repository%$'\r'}"
+            [ -z "$repository" ] && continue
+            if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+              echo "Invalid private dependency repository: $repository"
+              exit 1
+            fi
+            git ls-remote --exit-code "https://github.com/${{ github.repository_owner }}/${repository}.git" HEAD >/dev/null
+            repository_count=$((repository_count + 1))
+          done <<< "$PRIVATE_DEPENDENCY_REPOSITORIES"
+
+          if [ "$repository_count" -eq 0 ]; then
+            echo "PRIVATE_DEPENDENCY_REPOSITORIES must include at least one repository."
             exit 1
           fi
-          GIT_CONFIG_COUNT=1 \
-          GIT_CONFIG_KEY_0="url.https://x-access-token:${PAT_GITHUB}@github.com/.insteadOf" \
-          GIT_CONFIG_VALUE_0="https://github.com/" \
-            uv sync --all-groups --frozen
+          uv sync --all-groups --frozen
       - name: Validate image tag
         if: ${{ inputs.IMAGE_TAG != '' }}
         env:

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -43,14 +43,11 @@ on:
         type: string
         required: false
         default: ""
-        description: "Optional immutable image tag passed to CDK as `-c imageTag=<IMAGE_TAG>`."
+        description: "Optional full 40-character lowercase hex commit SHA passed to CDK as `-c imageTag=<IMAGE_TAG>`."
 
 permissions:
   id-token: write
   contents: read
-
-env:
-  GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
 
 jobs:
   provision:
@@ -61,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: ${{ inputs.PYTHON_VERSION }}
@@ -76,33 +73,61 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: cdk-deploy
           aws-region: ${{ inputs.AWS_REGION }}
-      - name: Configure private Git dependencies
-        run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Install dependencies
-        run: uv sync --all-groups --frozen
+        env:
+          PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+        run: |
+          if [ -z "$PAT_GITHUB" ]; then
+            echo "PAT_GITHUB is required for private Python dependencies."
+            exit 1
+          fi
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0="url.https://x-access-token:${PAT_GITHUB}@github.com/.insteadOf" \
+          GIT_CONFIG_VALUE_0="https://github.com/" \
+            uv sync --all-groups --frozen
       - name: Validate image tag
         if: ${{ inputs.IMAGE_TAG != '' }}
         env:
           IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
         run: |
-          if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
-            echo "IMAGE_TAG must be a valid Docker tag: start with a letter, digit, or underscore, then use only letters, digits, underscore, period, and dash."
+          if [[ ! "$IMAGE_TAG" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "IMAGE_TAG must be a full 40-character lowercase commit SHA."
+            exit 1
+          fi
+      - name: Validate deploy inputs
+        env:
+          DEPLOY_ENV: ${{ inputs.ENV }}
+          CDK_STACKS: ${{ inputs.CDK_STACKS }}
+        run: |
+          case "$DEPLOY_ENV" in
+            dev|qa|uat|prod) ;;
+            *)
+              echo "ENV must be one of: dev, qa, uat, prod."
+              exit 1
+              ;;
+          esac
+          if [[ ! "$CDK_STACKS" =~ ^(--all|[A-Za-z0-9:._/-]+([[:space:]][A-Za-z0-9:._/-]+)*)$ ]]; then
+            echo "CDK_STACKS must be --all or space-separated CDK stack names."
             exit 1
           fi
       - name: CDK synth (runs cdk-nag SOC2 checks)
         env:
+          DEPLOY_ENV: ${{ inputs.ENV }}
           IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
         run: |
-          args=(-c "env=${{ inputs.ENV }}")
+          args=(-c "env=$DEPLOY_ENV")
           if [ -n "$IMAGE_TAG" ]; then
             args+=(-c "imageTag=$IMAGE_TAG")
           fi
           uv run cdk synth "${args[@]}"
       - name: CDK deploy
         env:
+          DEPLOY_ENV: ${{ inputs.ENV }}
+          CDK_STACKS: ${{ inputs.CDK_STACKS }}
           IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
         run: |
-          args=(${{ inputs.CDK_STACKS }} -c "env=${{ inputs.ENV }}")
+          read -r -a stacks <<< "$CDK_STACKS"
+          args=("${stacks[@]}" -c "env=$DEPLOY_ENV")
           if [ -n "$IMAGE_TAG" ]; then
             args+=(-c "imageTag=$IMAGE_TAG")
           fi

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -39,6 +39,11 @@ on:
         type: string
         required: false
         default: "us-east-2"
+      IMAGE_TAG:
+        type: string
+        required: false
+        default: ""
+        description: "Optional immutable image tag passed to CDK as `-c imageTag=<IMAGE_TAG>`."
 
 permissions:
   id-token: write
@@ -71,9 +76,34 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           role-session-name: cdk-deploy
           aws-region: ${{ inputs.AWS_REGION }}
+      - name: Configure private Git dependencies
+        run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-groups --frozen
+      - name: Validate image tag
+        if: ${{ inputs.IMAGE_TAG != '' }}
+        env:
+          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+        run: |
+          if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "IMAGE_TAG must be a valid Docker tag: start with a letter, digit, or underscore, then use only letters, digits, underscore, period, and dash."
+            exit 1
+          fi
       - name: CDK synth (runs cdk-nag SOC2 checks)
-        run: uv run cdk synth -c env=${{ inputs.ENV }}
+        env:
+          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+        run: |
+          args=(-c "env=${{ inputs.ENV }}")
+          if [ -n "$IMAGE_TAG" ]; then
+            args+=(-c "imageTag=$IMAGE_TAG")
+          fi
+          uv run cdk synth "${args[@]}"
       - name: CDK deploy
-        run: uv run cdk deploy ${{ inputs.CDK_STACKS }} -c env=${{ inputs.ENV }} --require-approval never
+        env:
+          IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+        run: |
+          args=(${{ inputs.CDK_STACKS }} -c "env=${{ inputs.ENV }}")
+          if [ -n "$IMAGE_TAG" ]; then
+            args+=(-c "imageTag=$IMAGE_TAG")
+          fi
+          uv run cdk deploy "${args[@]}" --require-approval never

--- a/README.md
+++ b/README.md
@@ -17,6 +17,49 @@ For other package management tools, like `pip`, `poetry`, you can use the `pypro
 
 ## Reusable workflows
 
+### `cdk-deploy.yml` — Provision infrastructure with CDK
+
+Runs `uv sync --all-groups --frozen`, `cdk synth`, and `cdk deploy` for a
+consumer repository CDK app. Use this when a service repo owns its deployable
+`cdk.json` and stack code but wants the shared Travtus OIDC/CDK workflow shape.
+
+**Triggers:** `workflow_call`
+
+**Inputs:**
+
+| Name | Required | Default | Description |
+|---|---|---|---|
+| `ENV` | yes | — | One of `dev`, `qa`, `uat`, or `prod`; passed as `-c env=<ENV>`. |
+| `CDK_STACKS` | no | `--all` | `--all` or space-separated stack names for `cdk deploy`. |
+| `WORKING_DIRECTORY` | no | `.` | Directory containing `cdk.json`. |
+| `PYTHON_VERSION` | no | `3.13` | Python version for `uv`. |
+| `NODE_VERSION` | no | `20` | Node version for the CDK CLI. |
+| `CDK_VERSION` | no | `2.1128.0` | `aws-cdk` CLI version. |
+| `AWS_REGION` | no | `us-east-2` | AWS region for OIDC and CDK. |
+| `IMAGE_TAG` | no | empty | Optional full 40-character lowercase hex commit SHA passed as `-c imageTag=<IMAGE_TAG>`. |
+
+**Secrets:** `PAT_GITHUB`, `AWS_OIDC_ROLE_ARN` (required).
+
+`PAT_GITHUB` is currently used only inside the `uv sync` step through ephemeral
+Git config so private git dependencies can be resolved without persisting
+checkout credentials. Prefer replacing it with a short-lived GitHub App token
+once the shared app secret contract is available to callers.
+
+**Example:**
+```yaml
+jobs:
+  deploy-warehouse:
+    uses: Travtus/.github/.github/workflows/cdk-deploy.yml@main
+    secrets:
+      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+    with:
+      ENV: uat
+      CDK_STACKS: data-platform-warehouse-uat
+      WORKING_DIRECTORY: .
+      IMAGE_TAG: ${{ github.sha }}
+```
+
 ### `auto_assign_round_robin.yml` — PR reviewer assignment
 
 Assigns PR reviewers from the `Platform` and `frontend` GitHub teams based on changed file extensions. The workflow is intended to be selected as an organization ruleset required workflow, so individual repositories do not need caller workflows.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ is removed when the install step exits.
 The workflow synthesizes and runs `cdk diff` in a preview job, then uploads the
 resulting cloud assembly. A second job targets the GitHub Environment named by
 `ENV`, waits for its native protection rules, and deploys that exact assembly.
-Configure required reviewers and deployment-branch rules on UAT/prod
-environments; keep the caller pinned to an immutable workflow commit or release.
+Configure required reviewers and deployment-branch rules on every deployment
+environment; keep the caller pinned to an immutable workflow commit or release.
 
 With `PLAN_ONLY: true`, the preview uses a template-only `cdk diff`, publishes
 the result in the Actions job summary, and skips only the provision job. Normal

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ in its .github directory. This is for PR automation around the workflows themsel
 If you update this repository's template for automatic comments, then you should also update this repository's workflow
 for automatic comments.
 
+## Contents
+
+- [Project configuration file](#project-configuration-file)
+- [Reusable workflows](#reusable-workflows)
+  - [`cdk-deploy.yml`](#cdk-deploy)
+  - [`auto_assign_round_robin.yml`](#auto-assign-round-robin)
+  - [`pr_size_check.yml`](#pr-size-check)
+  - [`run-alembic-migrations.yml`](#run-alembic-migrations)
+  - [`deploy_ecs_service_to_env.yaml`](#deploy-ecs-service-to-env)
+
 ## Project configuration file
 
 If you use `uv` to manage your Python projects, please copy `pyproject-uv.toml` to your project root and rename it to `pyproject.toml`.
@@ -17,6 +27,7 @@ For other package management tools, like `pip`, `poetry`, you can use the `pypro
 
 ## Reusable workflows
 
+<a id="cdk-deploy"></a>
 ### `cdk-deploy.yml` — Provision infrastructure with CDK
 
 Runs `uv sync --all-groups --frozen`, `cdk synth`, and `cdk deploy` for a
@@ -65,6 +76,7 @@ jobs:
       PRIVATE_DEPENDENCY_REPOSITORIES: platform-infra-toolkit
 ```
 
+<a id="auto-assign-round-robin"></a>
 ### `auto_assign_round_robin.yml` — PR reviewer assignment
 
 Assigns PR reviewers from the `Platform` and `frontend` GitHub teams based on changed file extensions. The workflow is intended to be selected as an organization ruleset required workflow, so individual repositories do not need caller workflows.
@@ -115,6 +127,7 @@ Before enabling the workflow:
 ```
 ````
 
+<a id="pr-size-check"></a>
 ### `pr_size_check.yml` — PR size enforcement
 
 Fails a PR when the number of changed lines exceeds **750** (configurable in the workflow). Designed to keep PRs reviewable and aligned with trunk-based development.
@@ -139,6 +152,7 @@ Configure the repository variable `PLATFORM_ADMIN_APP_ID` with the GitHub App cl
 - Binary files (Git reports `-` in numstat)
 
 
+<a id="run-alembic-migrations"></a>
 ### `run-alembic-migrations.yml` — Run Alembic migrations on ECS
 
 Runs an Alembic command as a one-shot Fargate task using an existing ECS task definition (with a `containerOverrides` command). Waits for the task to finish, prints a CloudWatch log URL, and fails on non-zero exit.
@@ -177,6 +191,7 @@ jobs:
 
 ---
 
+<a id="deploy-ecs-service-to-env"></a>
 ### `deploy_ecs_service_to_env.yaml` — Deploy ECS service (build → migrate → restart)
 
 Orchestrates a full ECS service deploy for one environment by chaining three reusable workflows:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ consumer repository CDK app. Use this when a service repo owns its deployable
 | `IMAGE_TAG` | no | empty | Optional full 40-character lowercase hex commit SHA passed as `-c imageTag=<IMAGE_TAG>`. |
 | `PRIVATE_DEPENDENCY_REPOSITORIES` | no | `platform-infra-toolkit` | Newline-separated private Travtus repositories available to the install step. |
 | `DEPLOYMENT_ID` | no | `cdk` | Safe stable id used to name the reviewed cloud-assembly artifact; callers with multiple deploy jobs must use a unique value per job. |
+| `PLAN_ONLY` | no | `false` | Run synth and diff without running the provision job. Use this for pull-request plans. |
 
 **Secrets:** `PLATFORM_ADMIN_APP_PRIVATE_KEY`, `AWS_OIDC_ROLE_ARN` (required).
 
@@ -66,6 +67,10 @@ resulting cloud assembly. A second job targets the GitHub Environment named by
 `ENV`, waits for its native protection rules, and deploys that exact assembly.
 Configure required reviewers and deployment-branch rules on UAT/prod
 environments; keep the caller pinned to an immutable workflow commit or release.
+
+With `PLAN_ONLY: true`, the preview uses a template-only `cdk diff`, publishes
+the result in the Actions job summary, and skips only the provision job. Normal
+deployment calls still preview, wait for environment approval, and deploy.
 
 **Example:**
 ```yaml

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ consumer repository CDK app. Use this when a service repo owns its deployable
 | `AWS_REGION` | no | `us-east-2` | AWS region for OIDC and CDK. |
 | `IMAGE_TAG` | no | empty | Optional full 40-character lowercase hex commit SHA passed as `-c imageTag=<IMAGE_TAG>`. |
 | `PRIVATE_DEPENDENCY_REPOSITORIES` | no | `platform-infra-toolkit` | Newline-separated private Travtus repositories available to the install step. |
+| `DEPLOYMENT_ID` | no | `cdk` | Safe stable id used to name the reviewed cloud-assembly artifact; callers with multiple deploy jobs must use a unique value per job. |
 
 **Secrets:** `PLATFORM_ADMIN_APP_PRIVATE_KEY`, `AWS_OIDC_ROLE_ARN` (required).
 
@@ -59,6 +60,12 @@ The workflow mints a short-lived GitHub App token scoped to
 for each listed repository. Checkout credentials are not persisted, private
 repository access is verified before `uv sync`, and temporary Git URL rewriting
 is removed when the install step exits.
+
+The workflow synthesizes and runs `cdk diff` in a preview job, then uploads the
+resulting cloud assembly. A second job targets the GitHub Environment named by
+`ENV`, waits for its native protection rules, and deploys that exact assembly.
+Configure required reviewers and deployment-branch rules on UAT/prod
+environments; keep the caller pinned to an immutable workflow commit or release.
 
 **Example:**
 ```yaml
@@ -74,6 +81,7 @@ jobs:
       WORKING_DIRECTORY: .
       IMAGE_TAG: ${{ github.sha }}
       PRIVATE_DEPENDENCY_REPOSITORIES: platform-infra-toolkit
+      DEPLOYMENT_ID: warehouse-uat
 ```
 
 <a id="auto-assign-round-robin"></a>

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ consumer repository CDK app. Use this when a service repo owns its deployable
 | `CDK_VERSION` | no | `2.1128.0` | `aws-cdk` CLI version. |
 | `AWS_REGION` | no | `us-east-2` | AWS region for OIDC and CDK. |
 | `IMAGE_TAG` | no | empty | Optional full 40-character lowercase hex commit SHA passed as `-c imageTag=<IMAGE_TAG>`. |
+| `PRIVATE_DEPENDENCY_REPOSITORIES` | no | `platform-infra-toolkit` | Newline-separated private Travtus repositories available to the install step. |
 
-**Secrets:** `PAT_GITHUB`, `AWS_OIDC_ROLE_ARN` (required).
+**Secrets:** `PLATFORM_ADMIN_APP_PRIVATE_KEY`, `AWS_OIDC_ROLE_ARN` (required).
 
-`PAT_GITHUB` is currently used only inside the `uv sync` step through ephemeral
-Git config so private git dependencies can be resolved without persisting
-checkout credentials. Prefer replacing it with a short-lived GitHub App token
-once the shared app secret contract is available to callers.
+**Variables:** `PLATFORM_ADMIN_APP_ID` (required; the App client ID).
+
+The workflow mints a short-lived GitHub App token scoped to
+`PRIVATE_DEPENDENCY_REPOSITORIES`. The App installation needs `Contents: Read`
+for each listed repository. Checkout credentials are not persisted, private
+repository access is verified before `uv sync`, and temporary Git URL rewriting
+is removed when the install step exits.
 
 **Example:**
 ```yaml
@@ -51,13 +55,14 @@ jobs:
   deploy-warehouse:
     uses: Travtus/.github/.github/workflows/cdk-deploy.yml@main
     secrets:
-      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      PLATFORM_ADMIN_APP_PRIVATE_KEY: ${{ secrets.PLATFORM_ADMIN_APP_PRIVATE_KEY }}
       AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
     with:
       ENV: uat
       CDK_STACKS: data-platform-warehouse-uat
       WORKING_DIRECTORY: .
       IMAGE_TAG: ${{ github.sha }}
+      PRIVATE_DEPENDENCY_REPOSITORIES: platform-infra-toolkit
 ```
 
 ### `auto_assign_round_robin.yml` — PR reviewer assignment


### PR DESCRIPTION
## Summary
- add optional `IMAGE_TAG` input and pass it to CDK synth/deploy as `-c imageTag=<tag>`
- add `PLAN_ONLY` for pull-request infrastructure review
- in plan mode, synthesize and run template-only `cdk diff --no-change-set`, publish the diff to the Actions summary, upload the reviewed cloud assembly, and skip provisioning
- preserve the normal preview -> GitHub Environment approval -> deploy-exact-assembly path
- use frozen uv sync and short-lived scoped GitHub App authentication for private CDK dependencies

## Why
Data-platform needs immutable SHA-tagged runtime images and reviewable dev/UAT/prod infrastructure diffs before merge. The shared workflow previously had neither an image-tag input nor a non-mutating PR plan mode.

## Validation
- `uv run pytest -q .github/scripts/test_cdk_deploy_workflow.py` (6 passed)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/cdk-deploy.yml`
- downstream data-platform plan jobs passed for dev, UAT, and prod, with every provision job skipped

## Stack dependency
Required before the data-platform UAT deploy workflow can use `IMAGE_TAG` and before data-platform branch protection can require the three plan previews.
