### PR TITLE
fix: retry private dependency verification

### DIFF
--- a/.github/scripts/test_cdk_deploy_workflow.py
+++ b/.github/scripts/test_cdk_deploy_workflow.py
@@ -25,6 +25,14 @@ def test_private_dependency_credentials_are_ephemeral_and_verified() -> None:
     assert "uv sync --all-groups --frozen" in WORKFLOW
 
 
+def test_private_dependency_verification_retries_with_bounded_backoff() -> None:
+    assert "verify_private_repository()" in WORKFLOW
+    assert "local max_attempts=5" in WORKFLOW
+    assert 'sleep "$delay_seconds"' in WORKFLOW
+    assert "delay_seconds=$((delay_seconds * 2))" in WORKFLOW
+    assert 'verify_private_repository "$repository"' in WORKFLOW
+
+
 def test_image_tag_is_validated_and_passed_to_synth_and_deploy() -> None:
     assert "if: ${{ inputs.IMAGE_TAG != '' }}" in WORKFLOW
     assert '[[ ! "$IMAGE_TAG" =~ ^[0-9a-f]{40}$ ]]' in WORKFLOW
@@ -62,6 +70,7 @@ def test_readme_documents_the_caller_contract() -> None:
 if __name__ == "__main__":
     test_private_dependencies_use_scoped_github_app_auth()
     test_private_dependency_credentials_are_ephemeral_and_verified()
+    test_private_dependency_verification_retries_with_bounded_backoff()
     test_image_tag_is_validated_and_passed_to_synth_and_deploy()
     test_deploy_uses_reviewed_cloud_assembly_after_environment_approval()
     test_plan_only_publishes_diff_without_provisioning()

--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -110,6 +110,27 @@ jobs:
           trap cleanup_git_auth EXIT
           git config --global url."https://x-access-token:${PRIVATE_DEPENDENCY_TOKEN}@github.com/".insteadOf "https://github.com/"
 
+          verify_private_repository() {
+            local repository="$1"
+            local max_attempts=5
+            local attempt=1
+            local delay_seconds=2
+
+            while true; do
+              if git ls-remote --exit-code "https://github.com/${{ github.repository_owner }}/${repository}.git" HEAD >/dev/null; then
+                return 0
+              fi
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "Private dependency repository verification failed after ${max_attempts} attempts: ${repository}" >&2
+                return 1
+              fi
+              echo "Private dependency repository verification attempt ${attempt}/${max_attempts} failed for ${repository}; retrying in ${delay_seconds}s." >&2
+              sleep "$delay_seconds"
+              attempt=$((attempt + 1))
+              delay_seconds=$((delay_seconds * 2))
+            done
+          }
+
           repository_count=0
           while IFS= read -r repository; do
             repository="${repository%$'\r'}"
@@ -118,7 +139,7 @@ jobs:
               echo "Invalid private dependency repository: $repository"
               exit 1
             fi
-            git ls-remote --exit-code "https://github.com/${{ github.repository_owner }}/${repository}.git" HEAD >/dev/null
+            verify_private_repository "$repository"
             repository_count=$((repository_count + 1))
           done <<< "$PRIVATE_DEPENDENCY_REPOSITORIES"
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ consumer repository CDK app. Use this when a service repo owns its deployable
 The workflow mints a short-lived GitHub App token scoped to
 `PRIVATE_DEPENDENCY_REPOSITORIES`. The App installation needs `Contents: Read`
 for each listed repository. Checkout credentials are not persisted, private
-repository access is verified before `uv sync`, and temporary Git URL rewriting
-is removed when the install step exits.
+repository access is verified with bounded exponential backoff before `uv sync`
+to absorb transient GitHub 404s, persistent failures still stop the job, and
+temporary Git URL rewriting is removed when the install step exits.
 
 The workflow synthesizes and runs `cdk diff` in a preview job, then uploads the
 resulting cloud assembly. A second job targets the GitHub Environment named by


### PR DESCRIPTION
## Summary

- retry the authenticated private-repository probe up to five times with bounded 2/4/8/16-second backoff
- preserve the short-lived repository-scoped GitHub App token, fail-closed behavior, and cleanup trap
- cover and document the retry contract

## Evidence

- [data-platform run 30517906129, attempt 1](https://github.com/Travtus/data-platform/actions/runs/30517906129/attempts/1) minted the App token, then immediately failed `git ls-remote` with HTTP 404; rerunning the failed job succeeded
- [data-platform run 30016090386, attempt 1](https://github.com/Travtus/data-platform/actions/runs/30016090386/attempts/1) showed the same post-token `repository not found` failure on 2026-07-23

## Validation

- `uv run --python 3.13 --with pytest pytest .github/scripts`: 9 passed
- workflow YAML parse: passed
- `git diff --check`: passed